### PR TITLE
Add env example

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ Your project is live at:
 
 ## Build your app
 
+## Environment Variables
+
+Copy `env.example` to `.env.local` and fill in the variables.
+
+
 Continue building your app on:
 
 **[https://v0.dev/chat/projects/zVc3ijHfuT4](https://v0.dev/chat/projects/zVc3ijHfuT4)**

--- a/env.example
+++ b/env.example
@@ -1,0 +1,17 @@
+# Supabase
+NEXT_PUBLIC_SUPABASE_URL=https://YOUR_PROJECT_REF.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=YOUR_SERVICE_ROLE_KEY
+
+# Make.com webhook
+MAKE_WEBHOOK_URL=https://hook.eu2.make.com/2508303/…
+MAKE_WEBHOOK_SECRET=your-secret-value
+
+# Google Docs API
+GOOGLE_CREDENTIALS_JSON='{"type":…}'
+GOOGLE_DOCS_TEMPLATE_ID=1AbCdEfGhIjKlMnOpQrSt
+
+# SMTP (for sending PDFs by email)
+SMTP_HOST=smtp.yourprovider.com
+SMTP_PORT=465
+SMTP_USER=you@domain.com
+SMTP_PASS=yourSmtpPassword


### PR DESCRIPTION
## Summary
- document environment variable setup
- add `env.example` with placeholders for Supabase, Make.com, Google Docs, and SMTP

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e8a822ae48326a061e03556e0e6c5