### PR TITLE
Update README with install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,19 @@ Your project is live at:
 
 ## Build your app
 
+Install dependencies using `pnpm`:
+
+```bash
+pnpm install
+```
+
+You need these packages before running lint:
+
+```bash
+npm run lint
+```
+
+
 ## Environment Variables
 
 Copy `env.example` to `.env.local` and fill in the variables.


### PR DESCRIPTION
## Summary
- document installing dependencies in README
- note that running lint requires installed packages

## Testing
- `pnpm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e914b572483268936edb5ccce1cd2