### PR TITLE
Remove stray console logs

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -9,6 +9,7 @@ import NotificationSystem from "@/components/dashboard/notification-system"
 import AdminTools from "@/components/dashboard/admin-tools"
 import AuditLogs from "@/components/dashboard/audit-logs"
 import { supabase } from "@/lib/supabase"
+import { devLog } from "@/lib/dev-log"
 import type { SummaryWidgetData, ContractStats } from "@/lib/dashboard-types"
 import { FileText, FileCheck, FileX, CalendarClock, Users, Building } from "lucide-react"
 import { useToast } from "@/hooks/use-toast"
@@ -79,7 +80,7 @@ export default function DashboardPage() {
     const contractsChannel = supabase
       .channel("public:contracts:kpis") // Unique channel name for KPIs
       .on("postgres_changes", { event: "*", schema: "public", table: "contracts" }, (payload) => {
-        console.log("Contracts table change for KPIs received!", payload)
+        devLog("Contracts table change for KPIs received!", payload)
         fetchInitialStats()
         toast({
           title: "Dashboard Stats Updated",

--- a/app/promoters/profile-test/page.tsx
+++ b/app/promoters/profile-test/page.tsx
@@ -5,6 +5,7 @@
 
 import PromoterProfileForm from "@/components/promoter-profile-form"
 import type { PromoterProfile } from "@/lib/types"
+import { devLog } from "@/lib/dev-log"
 
 // Sample data for editing (optional)
 const samplePromoterToEdit: PromoterProfile = {
@@ -28,7 +29,7 @@ const samplePromoterToEdit: PromoterProfile = {
 
 export default function PromoterProfileTestPage() {
   const handleFormSubmit = (data: any) => {
-    console.log("Form submitted on test page:", data)
+    devLog("Form submitted on test page:", data)
     // You can add navigation or other actions here
   }
 

--- a/components/contract-generator-form.tsx
+++ b/components/contract-generator-form.tsx
@@ -20,6 +20,7 @@ import { Loader2 } from "lucide-react"
 import { DatePickerWithManualInput } from "./date-picker-with-manual-input"
 import ComboboxField from "@/components/combobox-field"
 import { motion } from "framer-motion"
+import { devLog } from "@/lib/dev-log"
 
 const sectionVariants = {
   hidden: { opacity: 0, x: -20 },
@@ -44,10 +45,10 @@ export default function ContractGeneratorForm() {
 
   const { data: promoters, isLoading: isLoadingPromoters } = usePromoters()
 
-  // Console log for debugging
+  // Debug output only in development
   useEffect(() => {
-    console.log("Employer Parties Data:", employerParties)
-    console.log("Client Parties Data:", clientParties)
+    devLog("Employer Parties Data:", employerParties)
+    devLog("Client Parties Data:", clientParties)
   }, [employerParties, clientParties])
 
   useEffect(() => {

--- a/components/dashboard/audit-logs.tsx
+++ b/components/dashboard/audit-logs.tsx
@@ -6,6 +6,7 @@ import { ScrollArea } from "@/components/ui/scroll-area"
 import { Input } from "@/components/ui/input"
 import { Search, Loader2, ArrowUpDown } from "lucide-react"
 import { supabase } from "@/lib/supabase"
+import { devLog } from "@/lib/dev-log"
 import type { AuditLogItem } from "@/lib/dashboard-types"
 import { useToast } from "@/hooks/use-toast"
 import { format } from "date-fns"
@@ -55,7 +56,7 @@ export default function AuditLogs() {
       .channel("public:audit_logs:feed") // Unique channel name
       .on("postgres_changes", { event: "INSERT", schema: "public", table: "audit_logs" }, (payload) => {
         const newLog = payload.new as any
-        console.log("New audit log received:", newLog)
+        devLog("New audit log received:", newLog)
         toast({
           title: "New Audit Log Entry",
           description: `${newLog.user_email || "System"} performed action: ${newLog.action}`,

--- a/components/dashboard/contract-reports-table.tsx
+++ b/components/dashboard/contract-reports-table.tsx
@@ -11,6 +11,7 @@ import { Badge } from "@/components/ui/badge"
 import { Download, Search, ArrowUpDown, Loader2 } from "lucide-react"
 import type { ContractReportItem } from "@/lib/dashboard-types"
 import { supabase } from "@/lib/supabase"
+import { devLog } from "@/lib/dev-log"
 import { format, parseISO, isValid } from "date-fns"
 import type { DateRange } from "react-day-picker"
 import { useToast } from "@/hooks/use-toast"
@@ -62,7 +63,7 @@ export default function ContractReportsTable() {
     // For views, Supabase Realtime listens to changes on the underlying tables.
     // So, we subscribe to `contracts`, `promoters`, and `parties`.
     const handleTableChange = (payload: any, tableName: string) => {
-      console.log(`${tableName} table change for view:`, payload)
+      devLog(`${tableName} table change for view:`, payload)
       toast({ title: "Contract Data Updated", description: `Refreshing contract list due to changes in ${tableName}.` })
       fetchContracts() // Refetch data from the view
     }

--- a/components/dashboard/notification-system.tsx
+++ b/components/dashboard/notification-system.tsx
@@ -5,6 +5,7 @@ import { BellRing, CheckCircle, XCircle, AlertTriangle, Info, Loader2 } from "lu
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Button } from "@/components/ui/button"
 import { supabase } from "@/lib/supabase"
+import { devLog } from "@/lib/dev-log"
 import type { NotificationItem } from "@/lib/dashboard-types"
 import { useToast } from "@/hooks/use-toast"
 import { formatDistanceToNow } from "date-fns"
@@ -74,7 +75,7 @@ export default function NotificationSystem() {
       .channel("public:notifications:feed") // Unique channel name
       .on("postgres_changes", { event: "INSERT", schema: "public", table: "notifications" }, (payload) => {
         const newNotif = payload.new as any
-        console.log("New notification received:", newNotif)
+        devLog("New notification received:", newNotif)
         toast({ title: "New Notification", description: newNotif.message })
         setNotifications((prev) =>
           [

--- a/components/dashboard/review-panel.tsx
+++ b/components/dashboard/review-panel.tsx
@@ -7,6 +7,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { ThumbsUp, ThumbsDown, MessageSquare, Loader2 } from "lucide-react"
 import { supabase } from "@/lib/supabase"
+import { devLog } from "@/lib/dev-log"
 import type { ReviewItem } from "@/lib/dashboard-types" // Ensure this type is defined
 import { useToast } from "@/hooks/use-toast"
 import { formatDistanceToNow } from "date-fns"
@@ -57,7 +58,7 @@ export default function ReviewPanel() {
         "postgres_changes",
         { event: "*", schema: "public", table: "contracts", filter: "status=eq.Pending Approval" },
         (payload) => {
-          console.log("Review items change:", payload)
+          devLog("Review items change:", payload)
           toast({ title: "New Item for Review", description: "An item has been submitted for review." })
           fetchReviewItems()
         },

--- a/components/promoter-profile-form.tsx
+++ b/components/promoter-profile-form.tsx
@@ -17,6 +17,7 @@ import { useToast } from "@/hooks/use-toast"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
+import { devLog } from "@/lib/dev-log"
 import { Switch } from "@/components/ui/switch"
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card"
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form"
@@ -88,7 +89,7 @@ export default function PromoterProfileForm({ promoterToEdit, onFormSubmitSucces
 
   async function onSubmit(values: PromoterProfileFormData) {
     setIsSubmitting(true)
-    console.log("Form values:", values)
+    devLog("Form values:", values)
 
     // Simulate API call
     await new Promise((resolve) => setTimeout(resolve, 1500))

--- a/hooks/use-contracts.ts
+++ b/hooks/use-contracts.ts
@@ -2,6 +2,7 @@
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import { supabase } from "@/lib/supabase" // Assuming supabase client is exported from here
+import { devLog } from "@/lib/dev-log"
 import type { Database } from "@/types/supabase"
 import { useEffect } from "react"
 
@@ -59,12 +60,12 @@ export const useContracts = () => {
     const channel = supabase
       .channel("public-contracts-realtime")
       .on("postgres_changes", { event: "*", schema: "public", table: "contracts" }, (payload) => {
-        console.log("Realtime contract change received!", payload)
+        devLog("Realtime contract change received!", payload)
         queryClient.invalidateQueries({ queryKey: queryKey })
       })
       .subscribe((status, err) => {
         if (status === "SUBSCRIBED") {
-          console.log("Subscribed to contracts channel!")
+          devLog("Subscribed to contracts channel!")
         }
         if (status === "CHANNEL_ERROR") {
           console.error("Channel error:", err)

--- a/lib/dev-log.ts
+++ b/lib/dev-log.ts
@@ -1,0 +1,5 @@
+export function devLog(...args: unknown[]): void {
+  if (process.env.NODE_ENV === "development") {
+    console.log(...args);
+  }
+}


### PR DESCRIPTION
## Summary
- create a helper `devLog` that only logs in development
- use `devLog` in place of direct `console.log` calls

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx jest` *(fails: 403 Forbidden during package install)*

------
https://chatgpt.com/codex/tasks/task_e_68523e8f37548326b13cca1735641790