### PR TITLE
Fix Make.com webhook env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ Your project is live at:
 ## Environment Variables
 
 Copy `env.example` to `.env.local` and fill in the variables.
+Important keys include:
+
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `SUPABASE_SERVICE_ROLE_KEY`
+- `NEXT_PUBLIC_MAKE_WEBHOOK_URL`
+- `MAKE_WEBHOOK_SECRET`
 
 
 Continue building your app on:

--- a/env.example
+++ b/env.example
@@ -3,7 +3,7 @@ NEXT_PUBLIC_SUPABASE_URL=https://YOUR_PROJECT_REF.supabase.co
 SUPABASE_SERVICE_ROLE_KEY=YOUR_SERVICE_ROLE_KEY
 
 # Make.com webhook
-MAKE_WEBHOOK_URL=https://hook.eu2.make.com/2508303/…
+NEXT_PUBLIC_MAKE_WEBHOOK_URL=https://hook.eu2.make.com/2508303/…
 MAKE_WEBHOOK_SECRET=your-secret-value
 
 # Google Docs API


### PR DESCRIPTION
## Summary
- add `NEXT_PUBLIC_` prefix for Make webhook URL in example env file
- document key environment variables, including the new webhook variable

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68523e8e21608326a57e4a9f341deed9