### PR TITLE
Fix server-side contract fetch

### DIFF
--- a/app/[locale]/contracts/[id]/page.tsx
+++ b/app/[locale]/contracts/[id]/page.tsx
@@ -1,4 +1,5 @@
 import { getContract } from "@/lib/data"
+import { getSupabaseAdmin } from "@/lib/supabase/admin"
 
 interface Props {
   params: {
@@ -8,7 +9,8 @@ interface Props {
 }
 
 export default async function ContractPage({ params: { id, locale } }: Props) {
-  const contract = await getContract(id)
+  const supabase = getSupabaseAdmin()
+  const contract = await getContract(supabase, id)
 
   if (!contract) {
     return <div>Contract not found</div>


### PR DESCRIPTION
## Summary
- use the admin Supabase client inside the contract page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68523e89ab9483269445336426511332