### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm exec next lint
+      - run: pnpm exec tsc --noEmit
+      - run: pnpm exec jest


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for lint, TypeScript checks and tests

## Testing
- `pnpm install --frozen-lockfile` *(fails: 403 from registry.npmjs.org)*
- `pnpm exec next lint` *(fails: command not found)*
- `pnpm exec tsc --noEmit` *(fails: missing dependencies)*
- `pnpm exec jest` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68523e83a3948326bd3c8ea3aed59ecd