### PR TITLE
Standardize MAKE_WEBHOOK_URL variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Your project is live at:
 
 Copy `env.example` to `.env.local` and fill in the variables.
 
+- `MAKE_WEBHOOK_URL` – the Make.com webhook endpoint used to generate PDF documents.
+
 
 Continue building your app on:
 

--- a/app/api/contracts/route.ts
+++ b/app/api/contracts/route.ts
@@ -7,9 +7,9 @@ import { contractGeneratorSchema } from "@/types/custom" // Your Zod schema for 
 // Placeholder for your PDF generation logic (e.g., calling Google Docs API via Make.com)
 async function generateBilingualPdf(contractData: any, contractId: string): Promise<string | null> {
   const supabaseAdmin = getSupabaseAdmin() // Get client instance
-  const makeWebhookUrl = process.env.NEXT_PUBLIC_MAKE_WEBHOOK_URL
+  const makeWebhookUrl = process.env.MAKE_WEBHOOK_URL
   if (!makeWebhookUrl) {
-    console.error("Make.com webhook URL (NEXT_PUBLIC_MAKE_WEBHOOK_URL) is not configured.")
+    console.error("Make.com webhook URL (MAKE_WEBHOOK_URL) is not configured.")
     return null
   }
 


### PR DESCRIPTION
## Summary
- use `MAKE_WEBHOOK_URL` in the contracts API route
- document `MAKE_WEBHOOK_URL` in the README

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68523e800a0883269837877237152a33