### PR TITLE
Fix File checks in schemas for non-browser use

### DIFF
--- a/lib/promoter-profile-schema.ts
+++ b/lib/promoter-profile-schema.ts
@@ -2,12 +2,17 @@ import { z } from "zod"
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5MB
 const ACCEPTED_IMAGE_TYPES = ["image/jpeg", "image/jpg", "image/png", "image/webp"]
+const isBrowser = typeof window !== "undefined" && typeof File !== "undefined"
 
 const fileSchema = z
   .any()
-  .refine((file) => !file || (file instanceof File && file.size <= MAX_FILE_SIZE), `Max file size is 5MB.`)
   .refine(
-    (file) => !file || (file instanceof File && ACCEPTED_IMAGE_TYPES.includes(file.type)),
+    (file) => !file || (isBrowser && file instanceof File && file.size <= MAX_FILE_SIZE),
+    `Max file size is 5MB.`,
+  )
+  .refine(
+    (file) =>
+      !file || (isBrowser && file instanceof File && ACCEPTED_IMAGE_TYPES.includes(file.type)),
     ".jpg, .jpeg, .png and .webp files are accepted.",
   )
   .optional()

--- a/lib/validations/contract.ts
+++ b/lib/validations/contract.ts
@@ -16,12 +16,17 @@ const dateSchemaDdMmYyyy = z
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5MB
 const ACCEPTED_IMAGE_TYPES = ["image/jpeg", "image/jpg", "image/png", "image/webp", "application/pdf"]
+const isBrowser = typeof window !== "undefined" && typeof File !== "undefined"
 
 const fileSchemaOptional = z
   .any()
-  .refine((file) => !file || (file instanceof File && file.size <= MAX_FILE_SIZE), `Max file size is 5MB.`)
   .refine(
-    (file) => !file || (file instanceof File && ACCEPTED_IMAGE_TYPES.includes(file.type)),
+    (file) => !file || (isBrowser && file instanceof File && file.size <= MAX_FILE_SIZE),
+    `Max file size is 5MB.`,
+  )
+  .refine(
+    (file) =>
+      !file || (isBrowser && file instanceof File && ACCEPTED_IMAGE_TYPES.includes(file.type)),
     ".jpg, .jpeg, .png, .webp, and .pdf files are accepted.",
   )
   .optional()


### PR DESCRIPTION
## Summary
- avoid using `instanceof File` on the server in contract and promoter schemas

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68523e7c67f48326b4e630bd92c941a2