### PR TITLE
Refactor getContract to use server supabase helper

### DIFF
--- a/lib/data.ts
+++ b/lib/data.ts
@@ -1,15 +1,15 @@
-import type { SupabaseClient } from "@supabase/supabase-js"
-import type { Database } from "@/types/supabase" // Adjust path if necessary
-import type { ContractWithRelations } from "@/types/custom" // Adjust path if necessary
+import type { ContractWithRelations } from "@/types/custom"
+import { supabaseServer } from "@/lib/supabase/server"
 
 export const getContract = async (
-  supabase: SupabaseClient<Database>,
   contractId: string,
 ): Promise<ContractWithRelations | null> => {
   if (!contractId) {
     console.warn("getContract called with no contractId")
     return null
   }
+
+  const supabase = supabaseServer()
 
   const { data, error } = await supabase
     .from("contracts")

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,0 +1,27 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js"
+import type { Database } from "@/types/supabase"
+
+/**
+ * Returns a Supabase client configured for server-side usage.
+ * A new client is created on each call to avoid sharing state between requests.
+ */
+export function supabaseServer(): SupabaseClient<Database> {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+  if (!supabaseUrl || !supabaseAnonKey) {
+    console.error(
+      "Supabase URL or Anon Key is missing. Check your environment variables."
+    )
+    throw new Error(
+      "Supabase URL or Anon Key is missing. Application cannot connect to the database."
+    )
+  }
+
+  return createClient<Database>(supabaseUrl, supabaseAnonKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  })
+}


### PR DESCRIPTION
## Summary
- introduce `supabaseServer` for server-side Supabase access
- refactor `getContract` to create its own Supabase client

## Testing
- `npx next lint` *(fails: 403 Forbidden because the environment lacks internet access)*

------
https://chatgpt.com/codex/tasks/task_e_68523c96a210832691d7cb820fb41edc