### PR TITLE
Add skeleton loading and error files

### DIFF
--- a/app/[locale]/contracts/[id]/error.tsx
+++ b/app/[locale]/contracts/[id]/error.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../../error.tsx"

--- a/app/[locale]/contracts/[id]/loading.tsx
+++ b/app/[locale]/contracts/[id]/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../../loading.tsx"

--- a/app/[locale]/contracts/error.tsx
+++ b/app/[locale]/contracts/error.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../error.tsx"

--- a/app/[locale]/error.tsx
+++ b/app/[locale]/error.tsx
@@ -1,0 +1,1 @@
+export { default } from "../error.tsx"

--- a/app/[locale]/generate-contract/error.tsx
+++ b/app/[locale]/generate-contract/error.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../error.tsx"

--- a/app/[locale]/generate-contract/loading.tsx
+++ b/app/[locale]/generate-contract/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../loading.tsx"

--- a/app/[locale]/loading.tsx
+++ b/app/[locale]/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "../loading.tsx"

--- a/app/[locale]/manage-parties/error.tsx
+++ b/app/[locale]/manage-parties/error.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../error.tsx"

--- a/app/[locale]/manage-parties/loading.tsx
+++ b/app/[locale]/manage-parties/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../loading.tsx"

--- a/app/[locale]/manage-promoters/error.tsx
+++ b/app/[locale]/manage-promoters/error.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../error.tsx"

--- a/app/[locale]/manage-promoters/loading.tsx
+++ b/app/[locale]/manage-promoters/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../loading.tsx"

--- a/app/client-layout.tsx
+++ b/app/client-layout.tsx
@@ -2,6 +2,8 @@
 
 import type React from "react"
 import { Inter, Lexend } from "next/font/google" // Lexend as display font
+import { Suspense } from "react"
+import Loading from "./loading"
 import { Toaster } from "@/components/ui/toaster"
 import { Providers } from "./providers" // Assuming this includes ThemeProvider
 import { LanguageSwitcher } from "@/components/language-switcher"
@@ -77,7 +79,9 @@ export default function ClientLayout({
 
             {/* MAIN CONTENT */}
             <main className="flex-1">
-              <div className="container py-8 md:py-12">{children}</div>
+              <Suspense fallback={<Loading />}>
+                <div className="container py-8 md:py-12">{children}</div>
+              </Suspense>
             </main>
 
             {/* FOOTER */}

--- a/app/contracts/[id]/edit/error.tsx
+++ b/app/contracts/[id]/edit/error.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../../error.tsx"

--- a/app/contracts/[id]/edit/loading.tsx
+++ b/app/contracts/[id]/edit/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../../loading.tsx"

--- a/app/contracts/[id]/error.tsx
+++ b/app/contracts/[id]/error.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../error.tsx"

--- a/app/contracts/[id]/loading.tsx
+++ b/app/contracts/[id]/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../loading.tsx"

--- a/app/contracts/error.tsx
+++ b/app/contracts/error.tsx
@@ -1,0 +1,1 @@
+export { default } from "../error.tsx"

--- a/app/contracts/loading.tsx
+++ b/app/contracts/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "../loading.tsx"

--- a/app/dashboard/analytics/error.tsx
+++ b/app/dashboard/analytics/error.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../error.tsx"

--- a/app/dashboard/analytics/loading.tsx
+++ b/app/dashboard/analytics/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../loading.tsx"

--- a/app/dashboard/audit/error.tsx
+++ b/app/dashboard/audit/error.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../error.tsx"

--- a/app/dashboard/audit/loading.tsx
+++ b/app/dashboard/audit/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../loading.tsx"

--- a/app/dashboard/contracts/error.tsx
+++ b/app/dashboard/contracts/error.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../error.tsx"

--- a/app/dashboard/contracts/loading.tsx
+++ b/app/dashboard/contracts/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../loading.tsx"

--- a/app/dashboard/error.tsx
+++ b/app/dashboard/error.tsx
@@ -1,0 +1,1 @@
+export { default } from "../error.tsx"

--- a/app/dashboard/loading.tsx
+++ b/app/dashboard/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "../loading.tsx"

--- a/app/dashboard/notifications/error.tsx
+++ b/app/dashboard/notifications/error.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../error.tsx"

--- a/app/dashboard/notifications/loading.tsx
+++ b/app/dashboard/notifications/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../loading.tsx"

--- a/app/dashboard/settings/error.tsx
+++ b/app/dashboard/settings/error.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../error.tsx"

--- a/app/dashboard/settings/loading.tsx
+++ b/app/dashboard/settings/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../loading.tsx"

--- a/app/dashboard/users/error.tsx
+++ b/app/dashboard/users/error.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../error.tsx"

--- a/app/dashboard/users/loading.tsx
+++ b/app/dashboard/users/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../loading.tsx"

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,11 @@
+"use client"
+
+export default function ErrorPage({ error, reset }: { error: Error; reset: () => void }) {
+  console.error(error)
+  return (
+    <div className="p-4 space-y-2">
+      <h2 className="font-semibold">Something went wrong!</h2>
+      <button onClick={() => reset()} className="underline text-sm">Try again</button>
+    </div>
+  )
+}

--- a/app/generate-contract/error.tsx
+++ b/app/generate-contract/error.tsx
@@ -1,0 +1,1 @@
+export { default } from "../error.tsx"

--- a/app/generate-contract/loading.tsx
+++ b/app/generate-contract/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "../loading.tsx"

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,0 +1,12 @@
+import { Skeleton } from "@/components/ui/skeleton"
+
+export default function Loading() {
+  return (
+    <div className="p-4 space-y-2">
+      <Skeleton className="h-8 w-1/3" />
+      <Skeleton className="h-4 w-full" />
+      <Skeleton className="h-4 w-full" />
+      <Skeleton className="h-4 w-2/3" />
+    </div>
+  )
+}

--- a/app/login/error.tsx
+++ b/app/login/error.tsx
@@ -1,0 +1,1 @@
+export { default } from "../error.tsx"

--- a/app/login/loading.tsx
+++ b/app/login/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "../loading.tsx"

--- a/app/manage-parties/error.tsx
+++ b/app/manage-parties/error.tsx
@@ -1,0 +1,1 @@
+export { default } from "../error.tsx"

--- a/app/manage-parties/loading.tsx
+++ b/app/manage-parties/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "../loading.tsx"

--- a/app/manage-promoters/[id]/edit/error.tsx
+++ b/app/manage-promoters/[id]/edit/error.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../../error.tsx"

--- a/app/manage-promoters/[id]/edit/loading.tsx
+++ b/app/manage-promoters/[id]/edit/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../../loading.tsx"

--- a/app/manage-promoters/[id]/error.tsx
+++ b/app/manage-promoters/[id]/error.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../error.tsx"

--- a/app/manage-promoters/[id]/loading.tsx
+++ b/app/manage-promoters/[id]/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../loading.tsx"

--- a/app/manage-promoters/error.tsx
+++ b/app/manage-promoters/error.tsx
@@ -1,0 +1,1 @@
+export { default } from "../error.tsx"

--- a/app/manage-promoters/loading.tsx
+++ b/app/manage-promoters/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "../loading.tsx"

--- a/app/promoters/profile-test/error.tsx
+++ b/app/promoters/profile-test/error.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../error.tsx"

--- a/app/promoters/profile-test/loading.tsx
+++ b/app/promoters/profile-test/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "../../loading.tsx"


### PR DESCRIPTION
## Summary
- add shared `loading.tsx` and `error.tsx`
- re-export those components for each route
- show skeleton fallback using `<Suspense>` in `client-layout`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68523c72a6388326b42e69efca257497