### PR TITLE
Update README with Supabase type generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,20 @@ Continue building your app on:
 2. Deploy your chats from the v0 interface
 3. Changes are automatically pushed to this repository
 4. Vercel deploys the latest version from this repository
+
+## Generate Supabase Types
+
+Install the [Supabase CLI](https://supabase.com/docs/guides/cli) globally:
+
+```bash
+npm install -g supabase
+```
+
+After installing, generate TypeScript definitions for your database:
+
+```bash
+npx supabase gen types typescript --project-id <YOUR_PROJECT_REF> --schema public > types/supabase.ts
+```
+
+Running this command whenever your database schema changes will keep
+`types/supabase.ts` in sync with your Supabase project.


### PR DESCRIPTION
## Summary
- document how to install Supabase CLI
- show the command to generate TypeScript types
- explain that the command keeps `types/supabase.ts` aligned with the schema

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68525b75ef1c8326ba39e8762a6089bb