### PR TITLE
Fix server file validation

### DIFF
--- a/lib/promoter-profile-schema.ts
+++ b/lib/promoter-profile-schema.ts
@@ -7,12 +7,19 @@ const isBrowser = typeof window !== "undefined" && typeof File !== "undefined"
 const fileSchema = z
   .any()
   .refine(
-    (file) => !file || (isBrowser && file instanceof File && file.size <= MAX_FILE_SIZE),
+    (file) =>
+      !file ||
+      (isBrowser
+        ? file instanceof File && file.size <= MAX_FILE_SIZE
+        : file.size <= MAX_FILE_SIZE),
     `Max file size is 5MB.`,
   )
   .refine(
     (file) =>
-      !file || (isBrowser && file instanceof File && ACCEPTED_IMAGE_TYPES.includes(file.type)),
+      !file ||
+      (isBrowser
+        ? file instanceof File && ACCEPTED_IMAGE_TYPES.includes(file.type)
+        : ACCEPTED_IMAGE_TYPES.includes(file.type)),
     ".jpg, .jpeg, .png and .webp files are accepted.",
   )
   .optional()

--- a/lib/validations/contract.ts
+++ b/lib/validations/contract.ts
@@ -21,12 +21,19 @@ const isBrowser = typeof window !== "undefined" && typeof File !== "undefined"
 const fileSchemaOptional = z
   .any()
   .refine(
-    (file) => !file || (isBrowser && file instanceof File && file.size <= MAX_FILE_SIZE),
+    (file) =>
+      !file ||
+      (isBrowser
+        ? file instanceof File && file.size <= MAX_FILE_SIZE
+        : file.size <= MAX_FILE_SIZE),
     `Max file size is 5MB.`,
   )
   .refine(
     (file) =>
-      !file || (isBrowser && file instanceof File && ACCEPTED_IMAGE_TYPES.includes(file.type)),
+      !file ||
+      (isBrowser
+        ? file instanceof File && ACCEPTED_IMAGE_TYPES.includes(file.type)
+        : ACCEPTED_IMAGE_TYPES.includes(file.type)),
     ".jpg, .jpeg, .png, .webp, and .pdf files are accepted.",
   )
   .optional()


### PR DESCRIPTION
## Summary
- handle file validation when running on the server by checking File existence
- apply the same logic to both promoter profile and contract schemas

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68525d1b71988326b22b19f84abfd0bf