### PR TITLE
Refactor browser detection

### DIFF
--- a/lib/promoter-profile-schema.ts
+++ b/lib/promoter-profile-schema.ts
@@ -1,8 +1,8 @@
 import { z } from "zod"
+import { isBrowser } from "./utils"
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5MB
 const ACCEPTED_IMAGE_TYPES = ["image/jpeg", "image/jpg", "image/png", "image/webp"]
-const isBrowser = typeof window !== "undefined" && typeof File !== "undefined"
 
 const fileSchema = z
   .any()

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,6 +1,13 @@
 import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
 
+/**
+ * Determine if the current runtime has access to the browser `File` API.
+ * This helps schemas validate file inputs only when the `File` constructor
+ * exists, which is not the case in server environments.
+ */
+export const isBrowser = typeof window !== "undefined" && typeof File !== "undefined"
+
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }

--- a/lib/validations/contract.ts
+++ b/lib/validations/contract.ts
@@ -1,5 +1,6 @@
 import { z } from "zod"
 import { isValid, parse } from "date-fns"
+import { isBrowser } from "../utils"
 
 // Helper for DD-MM-YYYY date string validation and transformation
 const dateSchemaDdMmYyyy = z
@@ -16,7 +17,6 @@ const dateSchemaDdMmYyyy = z
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5MB
 const ACCEPTED_IMAGE_TYPES = ["image/jpeg", "image/jpg", "image/png", "image/webp", "application/pdf"]
-const isBrowser = typeof window !== "undefined" && typeof File !== "undefined"
 
 const fileSchemaOptional = z
   .any()


### PR DESCRIPTION
## Summary
- share a single `isBrowser` helper
- use the helper in validation schemas

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68525d975ff483269c9b72b48f3547a7