### PR TITLE
Fix type imports

### DIFF
--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,48 @@
+export interface Party {
+  id: string
+  name_en: string
+  name_ar: string
+  crn: string
+  type?: string | null
+  created_at?: string | null
+  [key: string]: any
+}
+
+export interface Promoter {
+  id: string
+  name_en: string
+  name_ar: string
+  id_card_number: string
+  id_card_url?: string | null
+  passport_url?: string | null
+  employer_id?: string | null
+  outsourced_to_id?: string | null
+  job_title?: string | null
+  work_location?: string | null
+  status?: string | null
+  contract_valid_until?: string | null
+  id_card_expiry_date?: string | null
+  passport_expiry_date?: string | null
+  notify_before_id_expiry_days?: number | null
+  notify_before_passport_expiry_days?: number | null
+  notify_before_contract_expiry_days?: number | null
+  notes?: string | null
+  created_at?: string | null
+  [key: string]: any
+}
+
+export interface PromoterProfile extends Promoter {}
+
+export interface ContractRecord {
+  id: string
+  created_at?: string | null
+  first_party_name_en?: string | null
+  second_party_name_en?: string | null
+  promoter_name_en?: string | null
+  status?: string | null
+  google_doc_url?: string | null
+  error_details?: string | null
+  contract_start_date?: string | null
+  contract_end_date?: string | null
+  [key: string]: any
+}


### PR DESCRIPTION
## Summary
- add lib/types.ts with Party, Promoter, PromoterProfile and ContractRecord

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module '@supabase/supabase-js' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68525b70a06c832683fddb516e04ece1