### PR TITLE
Refactor schema utilities

### DIFF
--- a/lib/promoter-profile-schema.ts
+++ b/lib/promoter-profile-schema.ts
@@ -1,29 +1,15 @@
 import { z } from "zod"
-import { isBrowser } from "./utils"
+import { createOptionalFileSchema } from "./utils"
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5MB
 const ACCEPTED_IMAGE_TYPES = ["image/jpeg", "image/jpg", "image/png", "image/webp"]
 
-const fileSchema = z
-  .any()
-  .refine(
-    (file) =>
-      !file ||
-      (isBrowser
-        ? file instanceof File && file.size <= MAX_FILE_SIZE
-        : file.size <= MAX_FILE_SIZE),
-    `Max file size is 5MB.`,
-  )
-  .refine(
-    (file) =>
-      !file ||
-      (isBrowser
-        ? file instanceof File && ACCEPTED_IMAGE_TYPES.includes(file.type)
-        : ACCEPTED_IMAGE_TYPES.includes(file.type)),
-    ".jpg, .jpeg, .png and .webp files are accepted.",
-  )
-  .optional()
-  .nullable()
+const fileSchema = createOptionalFileSchema(
+  MAX_FILE_SIZE,
+  ACCEPTED_IMAGE_TYPES,
+  "Max file size is 5MB.",
+  ".jpg, .jpeg, .png and .webp files are accepted.",
+)
 
 const dateOptionalNullableSchema = z
   .date({

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,5 +1,6 @@
 import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
+import { z } from "zod"
 
 /**
  * Determine if the current runtime has access to the browser `File` API.
@@ -10,4 +11,37 @@ export const isBrowser = typeof window !== "undefined" && typeof File !== "undef
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
+}
+
+/**
+ * Build a zod schema for optional file inputs.
+ * This centralizes browser-aware file validation so individual schemas
+ * don't repeat the logic.
+ */
+export function createOptionalFileSchema(
+  maxFileSize: number,
+  acceptedTypes: string[],
+  sizeMessage: string,
+  typeMessage: string,
+) {
+  return z
+    .any()
+    .refine(
+      (file) =>
+        !file ||
+        (isBrowser
+          ? file instanceof File && file.size <= maxFileSize
+          : file.size <= maxFileSize),
+      sizeMessage,
+    )
+    .refine(
+      (file) =>
+        !file ||
+        (isBrowser
+          ? file instanceof File && acceptedTypes.includes(file.type)
+          : acceptedTypes.includes(file.type)),
+      typeMessage,
+    )
+    .optional()
+    .nullable()
 }

--- a/lib/validations/contract.ts
+++ b/lib/validations/contract.ts
@@ -1,6 +1,6 @@
 import { z } from "zod"
 import { isValid, parse } from "date-fns"
-import { isBrowser } from "../utils"
+import { createOptionalFileSchema } from "../utils"
 
 // Helper for DD-MM-YYYY date string validation and transformation
 const dateSchemaDdMmYyyy = z
@@ -18,26 +18,12 @@ const dateSchemaDdMmYyyy = z
 const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5MB
 const ACCEPTED_IMAGE_TYPES = ["image/jpeg", "image/jpg", "image/png", "image/webp", "application/pdf"]
 
-const fileSchemaOptional = z
-  .any()
-  .refine(
-    (file) =>
-      !file ||
-      (isBrowser
-        ? file instanceof File && file.size <= MAX_FILE_SIZE
-        : file.size <= MAX_FILE_SIZE),
-    `Max file size is 5MB.`,
-  )
-  .refine(
-    (file) =>
-      !file ||
-      (isBrowser
-        ? file instanceof File && ACCEPTED_IMAGE_TYPES.includes(file.type)
-        : ACCEPTED_IMAGE_TYPES.includes(file.type)),
-    ".jpg, .jpeg, .png, .webp, and .pdf files are accepted.",
-  )
-  .optional()
-  .nullable()
+const fileSchemaOptional = createOptionalFileSchema(
+  MAX_FILE_SIZE,
+  ACCEPTED_IMAGE_TYPES,
+  "Max file size is 5MB.",
+  ".jpg, .jpeg, .png, .webp, and .pdf files are accepted.",
+)
 
 export const ContractFormSchema = z
   .object({


### PR DESCRIPTION
## Summary
- centralize optional file validation in a helper
- refactor promoter and contract schemas to use the new helper

## Testing
- `npx tsc -p tsconfig.json` *(fails: cannot find modules)*
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68525e6abc2483269140149aa379b9be