### PR TITLE
Fix import paths for error/loading pages

### DIFF
--- a/app/[locale]/contracts/[id]/error.tsx
+++ b/app/[locale]/contracts/[id]/error.tsx
@@ -1,1 +1,1 @@
-export { default } from "../../../error.tsx"
+export { default } from "../../../error"

--- a/app/[locale]/contracts/[id]/loading.tsx
+++ b/app/[locale]/contracts/[id]/loading.tsx
@@ -1,1 +1,1 @@
-export { default } from "../../../loading.tsx"
+export { default } from "../../../loading"

--- a/app/[locale]/contracts/error.tsx
+++ b/app/[locale]/contracts/error.tsx
@@ -1,1 +1,1 @@
-export { default } from "../../error.tsx"
+export { default } from "../../error"

--- a/app/[locale]/error.tsx
+++ b/app/[locale]/error.tsx
@@ -1,1 +1,1 @@
-export { default } from "../error.tsx"
+export { default } from "../error"

--- a/app/[locale]/generate-contract/error.tsx
+++ b/app/[locale]/generate-contract/error.tsx
@@ -1,1 +1,1 @@
-export { default } from "../../error.tsx"
+export { default } from "../../error"

--- a/app/[locale]/generate-contract/loading.tsx
+++ b/app/[locale]/generate-contract/loading.tsx
@@ -1,1 +1,1 @@
-export { default } from "../../loading.tsx"
+export { default } from "../../loading"

--- a/app/[locale]/loading.tsx
+++ b/app/[locale]/loading.tsx
@@ -1,1 +1,1 @@
-export { default } from "../loading.tsx"
+export { default } from "../loading"

--- a/app/[locale]/manage-parties/error.tsx
+++ b/app/[locale]/manage-parties/error.tsx
@@ -1,1 +1,1 @@
-export { default } from "../../error.tsx"
+export { default } from "../../error"

--- a/app/[locale]/manage-parties/loading.tsx
+++ b/app/[locale]/manage-parties/loading.tsx
@@ -1,1 +1,1 @@
-export { default } from "../../loading.tsx"
+export { default } from "../../loading"

--- a/app/[locale]/manage-promoters/error.tsx
+++ b/app/[locale]/manage-promoters/error.tsx
@@ -1,1 +1,1 @@
-export { default } from "../../error.tsx"
+export { default } from "../../error"

--- a/app/[locale]/manage-promoters/loading.tsx
+++ b/app/[locale]/manage-promoters/loading.tsx
@@ -1,1 +1,1 @@
-export { default } from "../../loading.tsx"
+export { default } from "../../loading"

--- a/app/contracts/[id]/edit/error.tsx
+++ b/app/contracts/[id]/edit/error.tsx
@@ -1,1 +1,1 @@
-export { default } from "../../../error.tsx"
+export { default } from "../../../error"

--- a/app/contracts/[id]/edit/loading.tsx
+++ b/app/contracts/[id]/edit/loading.tsx
@@ -1,1 +1,1 @@
-export { default } from "../../../loading.tsx"
+export { default } from "../../../loading"

--- a/app/contracts/[id]/error.tsx
+++ b/app/contracts/[id]/error.tsx
@@ -1,1 +1,1 @@
-export { default } from "../../error.tsx"
+export { default } from "../../error"

--- a/app/contracts/[id]/loading.tsx
+++ b/app/contracts/[id]/loading.tsx
@@ -1,1 +1,1 @@
-export { default } from "../../loading.tsx"
+export { default } from "../../loading"

--- a/app/contracts/error.tsx
+++ b/app/contracts/error.tsx
@@ -1,1 +1,1 @@
-export { default } from "../error.tsx"
+export { default } from "../error"

--- a/app/contracts/loading.tsx
+++ b/app/contracts/loading.tsx
@@ -1,1 +1,1 @@
-export { default } from "../loading.tsx"
+export { default } from "../loading"

--- a/app/dashboard/analytics/error.tsx
+++ b/app/dashboard/analytics/error.tsx
@@ -1,1 +1,1 @@
-export { default } from "../../error.tsx"
+export { default } from "../../error"

--- a/app/dashboard/analytics/loading.tsx
+++ b/app/dashboard/analytics/loading.tsx
@@ -1,1 +1,1 @@
-export { default } from "../../loading.tsx"
+export { default } from "../../loading"

--- a/app/dashboard/audit/error.tsx
+++ b/app/dashboard/audit/error.tsx
@@ -1,1 +1,1 @@
-export { default } from "../../error.tsx"
+export { default } from "../../error"

--- a/app/dashboard/audit/loading.tsx
+++ b/app/dashboard/audit/loading.tsx
@@ -1,1 +1,1 @@
-export { default } from "../../loading.tsx"
+export { default } from "../../loading"

--- a/app/dashboard/contracts/error.tsx
+++ b/app/dashboard/contracts/error.tsx
@@ -1,1 +1,1 @@
-export { default } from "../../error.tsx"
+export { default } from "../../error"

--- a/app/dashboard/contracts/loading.tsx
+++ b/app/dashboard/contracts/loading.tsx
@@ -1,1 +1,1 @@
-export { default } from "../../loading.tsx"
+export { default } from "../../loading"

--- a/app/dashboard/error.tsx
+++ b/app/dashboard/error.tsx
@@ -1,1 +1,1 @@
-export { default } from "../error.tsx"
+export { default } from "../error"

--- a/app/dashboard/loading.tsx
+++ b/app/dashboard/loading.tsx
@@ -1,1 +1,1 @@
-export { default } from "../loading.tsx"
+export { default } from "../loading"

--- a/app/dashboard/notifications/error.tsx
+++ b/app/dashboard/notifications/error.tsx
@@ -1,1 +1,1 @@
-export { default } from "../../error.tsx"
+export { default } from "../../error"

--- a/app/dashboard/notifications/loading.tsx
+++ b/app/dashboard/notifications/loading.tsx
@@ -1,1 +1,1 @@
-export { default } from "../../loading.tsx"
+export { default } from "../../loading"

--- a/app/dashboard/settings/error.tsx
+++ b/app/dashboard/settings/error.tsx
@@ -1,1 +1,1 @@
-export { default } from "../../error.tsx"
+export { default } from "../../error"

--- a/app/dashboard/settings/loading.tsx
+++ b/app/dashboard/settings/loading.tsx
@@ -1,1 +1,1 @@
-export { default } from "../../loading.tsx"
+export { default } from "../../loading"

--- a/app/dashboard/users/error.tsx
+++ b/app/dashboard/users/error.tsx
@@ -1,1 +1,1 @@
-export { default } from "../../error.tsx"
+export { default } from "../../error"

--- a/app/dashboard/users/loading.tsx
+++ b/app/dashboard/users/loading.tsx
@@ -1,1 +1,1 @@
-export { default } from "../../loading.tsx"
+export { default } from "../../loading"

--- a/app/generate-contract/error.tsx
+++ b/app/generate-contract/error.tsx
@@ -1,1 +1,1 @@
-export { default } from "../error.tsx"
+export { default } from "../error"

--- a/app/generate-contract/loading.tsx
+++ b/app/generate-contract/loading.tsx
@@ -1,1 +1,1 @@
-export { default } from "../loading.tsx"
+export { default } from "../loading"

--- a/app/login/error.tsx
+++ b/app/login/error.tsx
@@ -1,1 +1,1 @@
-export { default } from "../error.tsx"
+export { default } from "../error"

--- a/app/login/loading.tsx
+++ b/app/login/loading.tsx
@@ -1,1 +1,1 @@
-export { default } from "../loading.tsx"
+export { default } from "../loading"

--- a/app/manage-parties/error.tsx
+++ b/app/manage-parties/error.tsx
@@ -1,1 +1,1 @@
-export { default } from "../error.tsx"
+export { default } from "../error"

--- a/app/manage-parties/loading.tsx
+++ b/app/manage-parties/loading.tsx
@@ -1,1 +1,1 @@
-export { default } from "../loading.tsx"
+export { default } from "../loading"

--- a/app/manage-promoters/[id]/edit/error.tsx
+++ b/app/manage-promoters/[id]/edit/error.tsx
@@ -1,1 +1,1 @@
-export { default } from "../../../error.tsx"
+export { default } from "../../../error"

--- a/app/manage-promoters/[id]/edit/loading.tsx
+++ b/app/manage-promoters/[id]/edit/loading.tsx
@@ -1,1 +1,1 @@
-export { default } from "../../../loading.tsx"
+export { default } from "../../../loading"

--- a/app/manage-promoters/[id]/error.tsx
+++ b/app/manage-promoters/[id]/error.tsx
@@ -1,1 +1,1 @@
-export { default } from "../../error.tsx"
+export { default } from "../../error"

--- a/app/manage-promoters/[id]/loading.tsx
+++ b/app/manage-promoters/[id]/loading.tsx
@@ -1,1 +1,1 @@
-export { default } from "../../loading.tsx"
+export { default } from "../../loading"

--- a/app/manage-promoters/error.tsx
+++ b/app/manage-promoters/error.tsx
@@ -1,1 +1,1 @@
-export { default } from "../error.tsx"
+export { default } from "../error"

--- a/app/manage-promoters/loading.tsx
+++ b/app/manage-promoters/loading.tsx
@@ -1,1 +1,1 @@
-export { default } from "../loading.tsx"
+export { default } from "../loading"

--- a/app/promoters/profile-test/error.tsx
+++ b/app/promoters/profile-test/error.tsx
@@ -1,1 +1,1 @@
-export { default } from "../../error.tsx"
+export { default } from "../../error"

--- a/app/promoters/profile-test/loading.tsx
+++ b/app/promoters/profile-test/loading.tsx
@@ -1,1 +1,1 @@
-export { default } from "../../loading.tsx"
+export { default } from "../../loading"


### PR DESCRIPTION
## Summary
- remove `.tsx` extension from re-export specifiers in `app/` to satisfy Node module resolution

## Testing
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852627d767c8326b1dca4164f4a2a76