### PR TITLE
Add root error entrypoint

### DIFF
--- a/error.tsx
+++ b/error.tsx
@@ -1,0 +1,1 @@
+export { default } from "./app/error";


### PR DESCRIPTION
## Summary
- expose the shared error page at `/error.tsx` for Next.js routing

## Testing
- `pnpm exec tsc` *(fails: Cannot find module zod, etc.)*
- `pnpm exec jest` *(fails: Command "jest" not found)*


------
https://chatgpt.com/codex/tasks/task_e_68526771a7888326b6a765f13b7de6e7