### PR TITLE
Clarify lint prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,16 +18,26 @@ Your project is live at:
 
 ## Build your app
 
-Install dependencies using `pnpm`:
+Install dependencies before running any scripts:
 
 ```bash
 pnpm install
+# or
+npm install
 ```
 
-You need these packages before running lint:
+After the dependencies are installed you can lint the project:
 
 ```bash
 npm run lint
+```
+
+If `next lint` reports "not found," install Next.js:
+
+```bash
+pnpm add next
+# or
+npm install next
 ```
 
 


### PR DESCRIPTION
## Summary
- clarify that dependencies must be installed before running `npm run lint`
- add a hint on installing Next.js if `next lint` cannot be found

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852679286148326be0ff3eaf16ba18f