### PR TITLE
Fix Contract import path

### DIFF
--- a/app/[locale]/contracts/page.tsx
+++ b/app/[locale]/contracts/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useMemo } from "react"
 import Link from "next/link"
 import { useContracts, useDeleteContractMutation } from "@/hooks/use-contracts"
-import type { Contract } from "@/hooks/use-contracts"
+import type { Contract } from "@/types/custom"
 import { Button } from "@/components/ui/button"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"


### PR DESCRIPTION
## Summary
- fix Contract type import in `contracts/page.tsx`

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_68526b4d8bf8832685291c6a7cfa0c23