### PR TITLE
Fix contract retrieval columns and page

### DIFF
--- a/app/[locale]/contracts/[id]/page.tsx
+++ b/app/[locale]/contracts/[id]/page.tsx
@@ -1,5 +1,4 @@
 import { getContract } from "@/lib/data"
-import { getSupabaseAdmin } from "@/lib/supabase/admin"
 
 interface Props {
   params: {
@@ -9,8 +8,7 @@ interface Props {
 }
 
 export default async function ContractPage({ params: { id, locale } }: Props) {
-  const supabase = getSupabaseAdmin()
-  const contract = await getContract(supabase, id)
+  const contract = await getContract(id)
 
   if (!contract) {
     return <div>Contract not found</div>
@@ -20,7 +18,7 @@ export default async function ContractPage({ params: { id, locale } }: Props) {
     <div>
       <h1>Contract Details</h1>
       <p>ID: {contract.id}</p>
-      <p>Name: {contract.name}</p>
+      <p>Job Title: {contract.job_title}</p>
       {/* Add more contract details here */}
     </div>
   )

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -1,4 +1,4 @@
-import type { ContractWithRelations } from "@/types/custom"
+import type { ContractWithRelations } from "@/hooks/use-contracts"
 import { supabaseServer } from "@/lib/supabase/server"
 
 export const getContract = async (
@@ -15,22 +15,18 @@ export const getContract = async (
     .from("contracts")
     .select(`
       id,
-      contract_name,
-      party_a_id,
-      party_b_id,
-      promoter_id,
-      start_date,
-      end_date,
-      status,
-      contract_terms_en,
-      contract_terms_fr,
       created_at,
-      updated_at,
-      user_id,
-      pdf_url, 
-      party_a:parties!contracts_party_a_id_fkey(id, name, address, representative_name),
-      party_b:parties!contracts_party_b_id_fkey(id, name, address, representative_name),
-      promoter:promoters!contracts_promoter_id_fkey(id, name, contact_email)
+      job_title,
+      contract_valid_from,
+      contract_valid_until,
+      status,
+      pdf_url,
+      first_party_id,
+      second_party_id,
+      promoter_id,
+      parties!contracts_employer_id_fkey (id, name_en, name_ar),
+      parties!contracts_client_id_fkey (id, name_en, name_ar),
+      promoters (id, name_en, name_ar)
     `)
     .eq("id", contractId)
     .single()


### PR DESCRIPTION
## Summary
- fetch contract details with correct column names
- simplify Contract page and remove unused Supabase client

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68526b4e4b44832693cad750a8cdfd87