### PR TITLE
Fix contract name display

### DIFF
--- a/app/[locale]/contracts/[id]/page.tsx
+++ b/app/[locale]/contracts/[id]/page.tsx
@@ -18,7 +18,9 @@ export default async function ContractPage({ params: { id, locale } }: Props) {
     <div>
       <h1>Contract Details</h1>
       <p>ID: {contract.id}</p>
-      <p>Job Title: {contract.job_title}</p>
+      <p>
+        Promoter: {contract.promoter_name_en || contract.promoters?.name_en || contract.promoters?.name_ar || "N/A"}
+      </p>
       {/* Add more contract details here */}
     </div>
   )


### PR DESCRIPTION
## Summary
- show promoter name in contract page instead of job title

## Testing
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68526d4a0b0c832696b156526885491d