### PR TITLE
Improve promoter name locale handling

### DIFF
--- a/app/[locale]/contracts/[id]/page.tsx
+++ b/app/[locale]/contracts/[id]/page.tsx
@@ -14,13 +14,18 @@ export default async function ContractPage({ params: { id, locale } }: Props) {
     return <div>Contract not found</div>
   }
 
+  const promoterName =
+    contract.promoter_name_en ||
+    (locale === "ar"
+      ? contract.promoters?.name_ar || contract.promoters?.name_en
+      : contract.promoters?.name_en || contract.promoters?.name_ar) ||
+    "N/A"
+
   return (
     <div>
       <h1>Contract Details</h1>
       <p>ID: {contract.id}</p>
-      <p>
-        Promoter: {contract.promoter_name_en || contract.promoters?.name_en || contract.promoters?.name_ar || "N/A"}
-      </p>
+      <p>Promoter: {promoterName}</p>
       {/* Add more contract details here */}
     </div>
   )


### PR DESCRIPTION
## Summary
- handle promoter name fallback by locale in contract details page

## Testing
- `pnpm lint` *(fails: next not found)*
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68526f0292708326867a8b8afaa14b3d