### PR TITLE
Fix promoter detail display

### DIFF
--- a/components/contract-generator-form.tsx
+++ b/components/contract-generator-form.tsx
@@ -3,7 +3,7 @@
 import { FormDescription } from "@/components/ui/form"
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select"
 import { useEffect, useState } from "react"
-import { useForm } from "react-hook-form"
+import { useForm, useWatch } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { toast } from "sonner"
@@ -91,7 +91,10 @@ export default function ContractGeneratorForm() {
     }
   }, [promoters])
 
-  const watchedPromoterId = form.watch("promoter_id")
+  const watchedPromoterId = useWatch({
+    control: form.control,
+    name: "promoter_id",
+  })
 
   useEffect(() => {
     if (watchedPromoterId && promoters) {

--- a/hooks/use-promoters.ts
+++ b/hooks/use-promoters.ts
@@ -1,11 +1,16 @@
 import { useQuery } from "@tanstack/react-query"
 import { supabase } from "@/lib/supabase"
+import { toast } from "sonner"
 import type { Promoter } from "@/types/custom"
 
 const fetchPromoters = async (): Promise<Promoter[]> => {
-  const { data, error } = await supabase.from("promoters").select("*").order("name_en", { ascending: true })
+  const { data, error } = await supabase
+    .from("promoters")
+    .select("*")
+    .order("name_en", { ascending: true })
   if (error) {
     console.error("Error fetching promoters:", error)
+    toast.error("Error loading promoters", { description: error.message })
     throw new Error(error.message)
   }
   return data || []
@@ -15,5 +20,6 @@ export const usePromoters = () => {
   return useQuery<Promoter[], Error>({
     queryKey: ["promoters"],
     queryFn: fetchPromoters,
+    staleTime: 1000 * 60 * 5,
   })
 }


### PR DESCRIPTION
## Summary
- use `useWatch` to properly react to promoter field changes
- show error toasts when promoter fetch fails and set query caching

## Testing
- `pnpm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685271025778832698abff1a48bf765b