### PR TITLE
Add ContractGeneratorForm tests

### DIFF
--- a/components/contract-generator-form.test.tsx
+++ b/components/contract-generator-form.test.tsx
@@ -1,43 +1,117 @@
-// Update imports and mocks if necessary due to React Query and type changes.
-// For example, mock the new React Query hooks:
-/*
-jest.mock('@/hooks/use-parties', () => ({
-  useParties: jest.fn(() => ({
-    data: [
-      { id: 'party-employer-1', name_en: 'Test Employer EN', name_ar: 'Test Employer AR', crn: 'CRN123', type: 'Employer' },
-    ],
-    isLoading: false,
-  })),
-}));
-jest.mock('@/hooks/use-promoters', () => ({
-  usePromoters: jest.fn(() => ({
-    data: [
-      { id: 'promoter-1', name_en: 'Test Promoter EN', name_ar: 'Test Promoter AR', id_card_number: 'ID123' },
-    ],
-    isLoading: false,
-  })),
-}));
-*/
-// The form submission test will now need to mock the API call to `/api/contracts`
-// instead of direct Supabase calls.
-/*
-global.fetch = jest.fn(() =>
-  Promise.resolve({
-    ok: true,
-    json: () => Promise.resolve({ message: 'Contract generated', contract: { id: 'new-contract-id', pdf_url: 'http://mockurl.com/contract.pdf' } }),
-  })
-) as jest.Mock;
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import ContractGeneratorForm from "./contract-generator-form"
+import { toast } from "sonner"
 
-// In the submission test:
-// await userEvent.click(screen.getByRole('button', { name: /generate contract/i }));
-// await waitFor(() => {
-//   expect(global.fetch).toHaveBeenCalledWith(
-//     '/api/contracts',
-//     expect.objectContaining({
-//       method: 'POST',
-//       body: expect.stringContaining('"first_party_id":"party-employer-1"'), // Check parts of the payload
-//     })
-//   );
-//   expect(toast).toHaveBeenCalledWith(expect.objectContaining({ title: 'Success' }));
-// });
-*/
+import { useParties } from "@/hooks/use-parties"
+import { usePromoters } from "@/hooks/use-promoters"
+
+jest.mock("@/hooks/use-parties")
+jest.mock("@/hooks/use-promoters")
+
+const mockUseParties = useParties as jest.Mock
+const mockUsePromoters = usePromoters as jest.Mock
+
+const employerParty = {
+  id: "party-employer-1",
+  name_en: "Test Employer EN",
+  name_ar: "Test Employer AR",
+  crn: "CRN123",
+  type: "Employer",
+}
+const clientParty = {
+  id: "party-client-1",
+  name_en: "Test Client EN",
+  name_ar: "Test Client AR",
+  crn: "CL123",
+  type: "Client",
+}
+const promoter = {
+  id: "promoter-1",
+  name_en: "Test Promoter EN",
+  name_ar: "Test Promoter AR",
+  id_card_number: "ID123",
+}
+
+function renderForm() {
+  const queryClient = new QueryClient()
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ContractGeneratorForm />
+    </QueryClientProvider>,
+  )
+}
+
+describe("ContractGeneratorForm", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseParties.mockImplementation((type: string) => {
+      if (type === "Employer") {
+        return { data: [employerParty], isLoading: false, error: undefined }
+      }
+      if (type === "Client") {
+        return { data: [clientParty], isLoading: false, error: undefined }
+      }
+      return { data: [], isLoading: false, error: undefined }
+    })
+    mockUsePromoters.mockReturnValue({
+      data: [promoter],
+      isLoading: false,
+      error: undefined,
+    })
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            message: "Contract generated",
+            contract: { id: "new-contract-id", pdf_url: "http://mockurl.com/contract.pdf" },
+          }),
+      }),
+    ) as jest.Mock
+  })
+
+  test("shows validation errors when required fields are missing", async () => {
+    renderForm()
+    const user = userEvent.setup()
+    await user.click(screen.getByRole("button", { name: /generate/i }))
+    expect(await screen.findByText("Please select Party A.")).toBeInTheDocument()
+    expect(await screen.findByText("Please select Party B.")).toBeInTheDocument()
+    expect(await screen.findByText("Please select a Promoter.")).toBeInTheDocument()
+    expect(await screen.findByText("Contract start date is required.")).toBeInTheDocument()
+    expect(await screen.findByText("Contract end date is required.")).toBeInTheDocument()
+    expect(await screen.findByText("Please enter a valid email address for notifications.")).toBeInTheDocument()
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  test("submits form with valid data", async () => {
+    renderForm()
+    const user = userEvent.setup()
+
+    const employerTrigger = screen.getByRole("combobox", { name: /select employer/i })
+    await user.click(employerTrigger)
+    await user.click(screen.getByRole("option", { name: /test employer en/i }))
+
+    const clientTrigger = screen.getByRole("combobox", { name: /select client/i })
+    await user.click(clientTrigger)
+    await user.click(screen.getByRole("option", { name: /test client en/i }))
+
+    const promoterCombo = screen.getByRole("combobox", { name: /select a promoter/i })
+    await user.click(promoterCombo)
+    await user.click(screen.getByRole("option", { name: /test promoter en/i }))
+
+    await user.type(screen.getByLabelText("Contract Start Date"), "01-01-2025")
+    await user.type(screen.getByLabelText("Contract End Date"), "02-01-2025")
+    await user.type(screen.getByLabelText("Notification Email"), "test@example.com")
+
+    await user.click(screen.getByRole("button", { name: /generate/i }))
+
+    await waitFor(() => expect(global.fetch).toHaveBeenCalledTimes(1))
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/contracts",
+      expect.objectContaining({ method: "POST" }),
+    )
+    expect((toast as any).success).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- add React Testing Library tests for ContractGeneratorForm

## Testing
- `npm run lint` *(fails: `next` not found)*
- `pnpm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68527e52edf083269a01c3efa6a92066