### PR TITLE
Fix toast auto-dismiss delay

### DIFF
--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -9,7 +9,7 @@ import type {
 } from "@/components/ui/toast"
 
 const TOAST_LIMIT = 1
-const TOAST_REMOVE_DELAY = 1000000
+const TOAST_REMOVE_DELAY = 5000
 
 type ToasterToast = ToastProps & {
   id: string


### PR DESCRIPTION
## Summary
- shorten the toast removal delay so notifications disappear in a reasonable amount of time

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852816dafe083268c7bf928bad4afa7