### PR TITLE
Add promoters table creation script

### DIFF
--- a/scripts/001_create_promoters_table.sql
+++ b/scripts/001_create_promoters_table.sql
@@ -1,0 +1,24 @@
+CREATE TABLE IF NOT EXISTS promoters (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name_en TEXT NOT NULL,
+    name_ar TEXT NOT NULL,
+    id_card_number TEXT NOT NULL,
+    id_card_url TEXT,
+    passport_url TEXT,
+    employer_id UUID REFERENCES parties(id) ON DELETE SET NULL,
+    outsourced_to_id UUID REFERENCES parties(id) ON DELETE SET NULL,
+    job_title TEXT,
+    work_location TEXT,
+    status TEXT DEFAULT 'active',
+    contract_valid_until DATE,
+    id_card_expiry_date DATE,
+    passport_expiry_date DATE,
+    notify_before_id_expiry_days INTEGER DEFAULT 30,
+    notify_before_passport_expiry_days INTEGER DEFAULT 90,
+    notify_before_contract_expiry_days INTEGER DEFAULT 30,
+    notes TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_promoters_employer_id ON promoters(employer_id);
+CREATE INDEX IF NOT EXISTS idx_promoters_outsourced_to_id ON promoters(outsourced_to_id);


### PR DESCRIPTION
## Summary
- add `001_create_promoters_table.sql` for the initial promoters table

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852816be98483268f65dfe3ac2177e9