### PR TITLE
Move promoter fixture data out of schema

### DIFF
--- a/components/promoter-profile-form.tsx
+++ b/components/promoter-profile-form.tsx
@@ -7,10 +7,12 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import {
   promoterProfileSchema,
   type PromoterProfileFormData,
+} from "@/lib/promoter-profile-schema"
+import {
   sampleEmployers,
   sampleClients,
   promoterStatuses,
-} from "@/lib/promoter-profile-schema"
+} from "@/lib/fixtures/promoter-profile"
 import type { PromoterProfile } from "@/lib/types" // Assuming PromoterProfile is defined in lib/types.ts
 import { useToast } from "@/hooks/use-toast"
 

--- a/lib/fixtures/promoter-profile.ts
+++ b/lib/fixtures/promoter-profile.ts
@@ -1,0 +1,17 @@
+export const sampleEmployers = [
+  { value: "agency_alpha", label: "Agency Alpha Solutions" },
+  { value: "beta_workforce", label: "Beta Workforce Inc." },
+  { value: "gamma_talents", label: "Gamma Talents Co." },
+]
+
+export const sampleClients = [
+  { value: "client_mega_corp", label: "MegaCorp International" },
+  { value: "client_tech_innovators", label: "Tech Innovators Ltd." },
+  { value: "client_global_retail", label: "Global Retail Group" },
+]
+
+export const promoterStatuses = [
+  { value: "active", label: "Active" },
+  { value: "inactive", label: "Inactive" },
+  { value: "suspended", label: "Suspended" },
+]

--- a/lib/promoter-profile-schema.ts
+++ b/lib/promoter-profile-schema.ts
@@ -39,22 +39,3 @@ export const promoterProfileSchema = z.object({
 })
 
 export type PromoterProfileFormData = z.infer<typeof promoterProfileSchema>
-
-// Sample data for dropdowns
-export const sampleEmployers = [
-  { value: "agency_alpha", label: "Agency Alpha Solutions" },
-  { value: "beta_workforce", label: "Beta Workforce Inc." },
-  { value: "gamma_talents", label: "Gamma Talents Co." },
-]
-
-export const sampleClients = [
-  { value: "client_mega_corp", label: "MegaCorp International" },
-  { value: "client_tech_innovators", label: "Tech Innovators Ltd." },
-  { value: "client_global_retail", label: "Global Retail Group" },
-]
-
-export const promoterStatuses = [
-  { value: "active", label: "Active" },
-  { value: "inactive", label: "Inactive" },
-  { value: "suspended", label: "Suspended" },
-]


### PR DESCRIPTION
## Summary
- move sample data arrays into `lib/fixtures/promoter-profile.ts`
- update `promoter-profile-schema.ts` to only hold validation logic
- load fixtures in `promoter-profile-form.tsx`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685281afd3ec83268e719ef93f640df7