### PR TITLE
Enable realtime updates on promoter list

### DIFF
--- a/app/[locale]/manage-promoters/page.tsx
+++ b/app/[locale]/manage-promoters/page.tsx
@@ -126,6 +126,31 @@ export default function ManagePromotersPage() {
     fetchPromotersWithContractCount()
   }, [])
 
+  useEffect(() => {
+    const promotersChannel = supabase
+      .channel("public:promoters:manage")
+      .on(
+        "postgres_changes",
+        { event: "*", schema: "public", table: "promoters" },
+        () => fetchPromotersWithContractCount(),
+      )
+      .subscribe()
+
+    const contractsChannel = supabase
+      .channel("public:contracts:manage")
+      .on(
+        "postgres_changes",
+        { event: "*", schema: "public", table: "contracts" },
+        () => fetchPromotersWithContractCount(),
+      )
+      .subscribe()
+
+    return () => {
+      supabase.removeChannel(promotersChannel)
+      supabase.removeChannel(contractsChannel)
+    }
+  }, [])
+
   const handleEdit = (promoter: Promoter) => {
     setSelectedPromoter(promoter)
     setShowForm(true)

--- a/app/manage-promoters/page.tsx
+++ b/app/manage-promoters/page.tsx
@@ -126,6 +126,31 @@ export default function ManagePromotersPage() {
     fetchPromotersWithContractCount()
   }, [])
 
+  useEffect(() => {
+    const promotersChannel = supabase
+      .channel("public:promoters:manage")
+      .on(
+        "postgres_changes",
+        { event: "*", schema: "public", table: "promoters" },
+        () => fetchPromotersWithContractCount(),
+      )
+      .subscribe()
+
+    const contractsChannel = supabase
+      .channel("public:contracts:manage")
+      .on(
+        "postgres_changes",
+        { event: "*", schema: "public", table: "contracts" },
+        () => fetchPromotersWithContractCount(),
+      )
+      .subscribe()
+
+    return () => {
+      supabase.removeChannel(promotersChannel)
+      supabase.removeChannel(contractsChannel)
+    }
+  }, [])
+
   const handleEdit = (promoter: Promoter) => {
     setSelectedPromoter(promoter)
     setShowForm(true)


### PR DESCRIPTION
## Summary
- subscribe to `promoters` and `contracts` table events on manage-promoters pages
- refresh the table when changes occur via Supabase realtime

## Testing
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68528acc78d483269611f9e297cb5156