### PR TITLE
Centralize contract schema

### DIFF
--- a/app/api/contracts/route.ts
+++ b/app/api/contracts/route.ts
@@ -2,7 +2,7 @@ import { type NextRequest, NextResponse } from "next/server"
 // Import the lazy-initialized admin client
 import { getSupabaseAdmin } from "@/lib/supabase/admin"
 import { createServerComponentClient } from "@/lib/supabaseServer"
-import { contractGeneratorSchema } from "@/types/custom" // Your Zod schema for validation
+import { contractGeneratorSchema } from "@/lib/schema-generator" // Your Zod schema for validation
 import type { BilingualPdfData } from "@/lib/types"
 // Removed direct import of Database type from here, as it's handled in admin.ts
 

--- a/components/contract-generator-form.tsx
+++ b/components/contract-generator-form.tsx
@@ -9,7 +9,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { toast } from "sonner"
 import { format } from "date-fns"
 
-import { contractGeneratorSchema, type ContractGeneratorFormData } from "@/types/custom"
+import { contractGeneratorSchema, type ContractGeneratorFormData } from "@/lib/schema-generator"
 import { useParties, type Party as PartyType } from "@/hooks/use-parties" // Import Party type if needed
 import { usePromoters } from "@/hooks/use-promoters"
 import type { Promoter } from "@/types/custom"

--- a/types/custom.ts
+++ b/types/custom.ts
@@ -28,24 +28,3 @@ export const promoterStatusesList = [
   { value: "pending_review", label: "Pending Review" },
   // Add other statuses if needed
 ]
-
-// Zod schema for the Contract Generator Form
-// This should align with the fields in ContractGeneratorForm and the API payload
-export const contractGeneratorSchema = z
-  .object({
-    first_party_id: z.string().uuid("Please select Party A."),
-    second_party_id: z.string().uuid("Please select Party B."),
-    promoter_id: z.string().uuid("Please select a Promoter."),
-    contract_start_date: z.date({ required_error: "Contract start date is required." }),
-    contract_end_date: z.date({ required_error: "Contract end date is required." }),
-    email: z.string().email("Please enter a valid email address for notifications."),
-    job_title: z.string().optional().nullable(), // Example optional field
-    work_location: z.string().optional().nullable(), // Example optional field
-    // Add other fields as necessary
-  })
-  .refine((data) => data.contract_end_date > data.contract_start_date, {
-    message: "End date must be after start date.",
-    path: ["contract_end_date"], // Path of error
-  })
-
-export type ContractGeneratorFormData = z.infer<typeof contractGeneratorSchema>


### PR DESCRIPTION
## Summary
- remove duplicate contract schema in `types/custom.ts`
- import schema and type from `lib/schema-generator.ts` in the form and API route

## Testing
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68530c00203883269e8f7eb8c092e9b0