### PR TITLE
Use env variable for form action

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ After the dependencies are installed you can lint the project:
 npm run lint
 ```
 
+The form at `public/index.html` is generated from `index.html` using the
+`NEXT_PUBLIC_MAKE_WEBHOOK_URL` environment variable. When you run `npm run dev`
+or `npm run build`, the script `scripts/build-form.js` replaces the placeholder
+`__MAKE_WEBHOOK_URL__` in `index.html` and writes the result to
+`public/index.html`.
+
 If `next lint` reports "not found," install Next.js:
 
 ```bash
@@ -59,7 +65,7 @@ others should remain server-side. Important keys include:
 | `NEXT_PUBLIC_SUPABASE_URL` | Base URL of your Supabase project | client |
 | `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Supabase anon key used by the browser | client |
 | `SUPABASE_SERVICE_ROLE_KEY` | Service role key for Supabase admin operations | server |
-| `NEXT_PUBLIC_MAKE_WEBHOOK_URL` | Public URL for Make.com form submissions | client |
+| `NEXT_PUBLIC_MAKE_WEBHOOK_URL` | Public URL for Make.com form submissions; used to generate `public/index.html` | client |
 | `MAKE_WEBHOOK_URL` | Make.com endpoint for generating PDFs | server |
 | `MAKE_WEBHOOK_SECRET` | Optional secret for Make.com, not referenced yet | server |
 | `GOOGLE_CREDENTIALS_JSON` | Google service account credentials | server |

--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@
 <body>
     <div class="form-container">
         <!-- action URL should match MAKE_WEBHOOK_URL -->
-        <form action="https://hook.make.com/your-webhook-id" method="POST" target="_blank">
+        <form action="__MAKE_WEBHOOK_URL__" method="POST" target="_blank">
             <h2>Contract Generation Request</h2>
             <div>
                 <label for="email">Email address:</label>

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "build": "next build",
-    "dev": "next dev",
+    "build": "node scripts/build-form.js && next build",
+    "dev": "node scripts/build-form.js && next dev",
     "lint": "next lint",
     "start": "next start",
     "test": "jest"

--- a/public/index.html
+++ b/public/index.html
@@ -67,7 +67,7 @@
 </head>
 <body>
     <div class="form-container">
-        <form action="https://hook.eu2.make.com/7wnygg029nwwo3uq52ynktdrp1qnihef" method="POST" target="_blank">
+        <form action="__MAKE_WEBHOOK_URL__" method="POST" target="_blank">
             <h2>Contract Generation Request</h2>
             <div>
                 <label for="email">Email address:</label>

--- a/scripts/build-form.js
+++ b/scripts/build-form.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+const path = require('path');
+
+const { NEXT_PUBLIC_MAKE_WEBHOOK_URL } = process.env;
+
+if (!NEXT_PUBLIC_MAKE_WEBHOOK_URL) {
+  console.error('NEXT_PUBLIC_MAKE_WEBHOOK_URL is not defined');
+  process.exit(1);
+}
+
+const templatePath = path.join(__dirname, '..', 'index.html');
+const outputPath = path.join(__dirname, '..', 'public', 'index.html');
+
+let content = fs.readFileSync(templatePath, 'utf8');
+content = content.replace(/__MAKE_WEBHOOK_URL__/g, NEXT_PUBLIC_MAKE_WEBHOOK_URL);
+fs.writeFileSync(outputPath, content);
+console.log(`Wrote ${outputPath}`);
+


### PR DESCRIPTION
## Summary
- build `public/index.html` from `index.html` using a new script
- call the script in `dev` and `build` npm commands
- document the build step in README
- use a placeholder for `action` in the form template

## Testing
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68530c037ed88326b30817d86299d35d