### PR TITLE
Fix error page re-export

### DIFF
--- a/error.tsx
+++ b/error.tsx
@@ -1,1 +1,4 @@
-export { default } from "./app/error";
+// Re-export the global error page from the app directory using the alias
+// defined in tsconfig.json. This avoids runtime resolution issues when Next.js
+// attempts to load the module using a relative specifier.
+export { default } from "@/app/error";


### PR DESCRIPTION
## Summary
- use tsconfig path alias when re-exporting the error page

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853117861dc83269b474d359d474925