### PR TITLE
Fix fetch mocking side effects

### DIFF
--- a/components/contract-generator-form.test.tsx
+++ b/components/contract-generator-form.test.tsx
@@ -13,6 +13,8 @@ jest.mock("@/hooks/use-promoters")
 const mockUseParties = useParties as jest.Mock
 const mockUsePromoters = usePromoters as jest.Mock
 
+const originalFetch = global.fetch
+
 const employerParty = {
   id: "party-employer-1",
   name_en: "Test Employer EN",
@@ -70,6 +72,10 @@ describe("ContractGeneratorForm", () => {
           }),
       }),
     ) as jest.Mock
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
   })
 
   test("shows validation errors when required fields are missing", async () => {


### PR DESCRIPTION
## Summary
- restore the original `global.fetch` after each `ContractGeneratorForm` test to prevent side effects

## Testing
- `pnpm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685313a1cd14832687f7565231c4c6ce