### PR TITLE
Move global error component

### DIFF
--- a/app/[locale]/contracts/[id]/error.tsx
+++ b/app/[locale]/contracts/[id]/error.tsx
@@ -1,4 +1,4 @@
 "use client"
 
-import ErrorPage from '@/error'
+import ErrorPage from '@/app/error'
 export default ErrorPage

--- a/app/[locale]/contracts/error.tsx
+++ b/app/[locale]/contracts/error.tsx
@@ -1,4 +1,4 @@
 "use client"
 
-import ErrorPage from '@/error'
+import ErrorPage from '@/app/error'
 export default ErrorPage

--- a/app/[locale]/error.tsx
+++ b/app/[locale]/error.tsx
@@ -1,4 +1,4 @@
 "use client"
 
-import ErrorPage from '@/error'
+import ErrorPage from '@/app/error'
 export default ErrorPage

--- a/app/[locale]/generate-contract/error.tsx
+++ b/app/[locale]/generate-contract/error.tsx
@@ -1,4 +1,4 @@
 "use client"
 
-import ErrorPage from '@/error'
+import ErrorPage from '@/app/error'
 export default ErrorPage

--- a/app/[locale]/manage-parties/error.tsx
+++ b/app/[locale]/manage-parties/error.tsx
@@ -1,4 +1,4 @@
 "use client"
 
-import ErrorPage from '@/error'
+import ErrorPage from '@/app/error'
 export default ErrorPage

--- a/app/[locale]/manage-promoters/error.tsx
+++ b/app/[locale]/manage-promoters/error.tsx
@@ -1,4 +1,4 @@
 "use client"
 
-import ErrorPage from '@/error'
+import ErrorPage from '@/app/error'
 export default ErrorPage

--- a/app/contracts/[id]/edit/error.tsx
+++ b/app/contracts/[id]/edit/error.tsx
@@ -1,4 +1,4 @@
 "use client"
 
-import ErrorPage from '@/error'
+import ErrorPage from '@/app/error'
 export default ErrorPage

--- a/app/contracts/[id]/error.tsx
+++ b/app/contracts/[id]/error.tsx
@@ -1,4 +1,4 @@
 "use client"
 
-import ErrorPage from '@/error'
+import ErrorPage from '@/app/error'
 export default ErrorPage

--- a/app/contracts/error.tsx
+++ b/app/contracts/error.tsx
@@ -1,4 +1,4 @@
 "use client"
 
-import ErrorPage from '@/error'
+import ErrorPage from '@/app/error'
 export default ErrorPage

--- a/app/dashboard/analytics/error.tsx
+++ b/app/dashboard/analytics/error.tsx
@@ -1,4 +1,4 @@
 "use client"
 
-import ErrorPage from '@/error'
+import ErrorPage from '@/app/error'
 export default ErrorPage

--- a/app/dashboard/audit/error.tsx
+++ b/app/dashboard/audit/error.tsx
@@ -1,4 +1,4 @@
 "use client"
 
-import ErrorPage from '@/error'
+import ErrorPage from '@/app/error'
 export default ErrorPage

--- a/app/dashboard/contracts/error.tsx
+++ b/app/dashboard/contracts/error.tsx
@@ -1,4 +1,4 @@
 "use client"
 
-import ErrorPage from '@/error'
+import ErrorPage from '@/app/error'
 export default ErrorPage

--- a/app/dashboard/error.tsx
+++ b/app/dashboard/error.tsx
@@ -1,4 +1,4 @@
 "use client"
 
-import ErrorPage from '@/error'
+import ErrorPage from '@/app/error'
 export default ErrorPage

--- a/app/dashboard/notifications/error.tsx
+++ b/app/dashboard/notifications/error.tsx
@@ -1,4 +1,4 @@
 "use client"
 
-import ErrorPage from '@/error'
+import ErrorPage from '@/app/error'
 export default ErrorPage

--- a/app/dashboard/settings/error.tsx
+++ b/app/dashboard/settings/error.tsx
@@ -1,4 +1,4 @@
 "use client"
 
-import ErrorPage from '@/error'
+import ErrorPage from '@/app/error'
 export default ErrorPage

--- a/app/dashboard/users/error.tsx
+++ b/app/dashboard/users/error.tsx
@@ -1,4 +1,4 @@
 "use client"
 
-import ErrorPage from '@/error'
+import ErrorPage from '@/app/error'
 export default ErrorPage

--- a/app/generate-contract/error.tsx
+++ b/app/generate-contract/error.tsx
@@ -1,4 +1,4 @@
 "use client"
 
-import ErrorPage from '@/error'
+import ErrorPage from '@/app/error'
 export default ErrorPage

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,0 +1,11 @@
+"use client"
+
+export default function ErrorPage({ error, reset }: { error: Error; reset: () => void }) {
+  console.error(error)
+  return (
+    <div className="p-4 space-y-2">
+      <h2 className="font-semibold">Something went wrong!</h2>
+      <button onClick={() => reset()} className="underline text-sm">Try again</button>
+    </div>
+  )
+}

--- a/app/login/error.tsx
+++ b/app/login/error.tsx
@@ -1,4 +1,4 @@
 "use client"
 
-import ErrorPage from '@/error'
+import ErrorPage from '@/app/error'
 export default ErrorPage

--- a/app/manage-parties/error.tsx
+++ b/app/manage-parties/error.tsx
@@ -1,4 +1,4 @@
 "use client"
 
-import ErrorPage from '@/error'
+import ErrorPage from '@/app/error'
 export default ErrorPage

--- a/app/manage-promoters/[id]/edit/error.tsx
+++ b/app/manage-promoters/[id]/edit/error.tsx
@@ -1,4 +1,4 @@
 "use client"
 
-import ErrorPage from '@/error'
+import ErrorPage from '@/app/error'
 export default ErrorPage

--- a/app/manage-promoters/[id]/error.tsx
+++ b/app/manage-promoters/[id]/error.tsx
@@ -1,4 +1,4 @@
 "use client"
 
-import ErrorPage from '@/error'
+import ErrorPage from '@/app/error'
 export default ErrorPage

--- a/app/manage-promoters/error.tsx
+++ b/app/manage-promoters/error.tsx
@@ -1,4 +1,4 @@
 "use client"
 
-import ErrorPage from '@/error'
+import ErrorPage from '@/app/error'
 export default ErrorPage

--- a/app/promoters/profile-test/error.tsx
+++ b/app/promoters/profile-test/error.tsx
@@ -1,4 +1,4 @@
 "use client"
 
-import ErrorPage from '@/error'
+import ErrorPage from '@/app/error'
 export default ErrorPage

--- a/error.tsx
+++ b/error.tsx
@@ -1,4 +1,0 @@
-// Re-export the global error page from the app directory using the alias
-// defined in tsconfig.json. This avoids runtime resolution issues when Next.js
-// attempts to load the module using a relative specifier.
-export { default } from "@/app/error";


### PR DESCRIPTION
## Summary
- create `app/global-error.tsx`
- remove root `error.tsx`
- update imports that referenced `@/error`

## Testing
- `tsc --noEmit` *(fails: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists)*

------
https://chatgpt.com/codex/tasks/task_e_685313c439248326a4738e048c7a22a5