### PR TITLE
Fix duplicate channel subscriptions

### DIFF
--- a/app/[locale]/manage-promoters/page.tsx
+++ b/app/[locale]/manage-promoters/page.tsx
@@ -124,20 +124,6 @@ export default function ManagePromotersPage() {
 
   useEffect(() => {
     fetchPromotersWithContractCount()
-    const channel = supabase
-      .channel("public:promoters:manage")
-      .on(
-        "postgres_changes",
-        { event: "*", schema: "public", table: "promoters" },
-        () => fetchPromotersWithContractCount(),
-      )
-      .subscribe()
-    return () => {
-      supabase.removeChannel(channel)
-    }
-  }, [])
-
-  useEffect(() => {
     const promotersChannel = supabase
       .channel("public:promoters:manage")
       .on(

--- a/app/manage-promoters/page.tsx
+++ b/app/manage-promoters/page.tsx
@@ -124,20 +124,6 @@ export default function ManagePromotersPage() {
 
   useEffect(() => {
     fetchPromotersWithContractCount()
-    const channel = supabase
-      .channel("public:promoters:manage")
-      .on(
-        "postgres_changes",
-        { event: "*", schema: "public", table: "promoters" },
-        () => fetchPromotersWithContractCount(),
-      )
-      .subscribe()
-    return () => {
-      supabase.removeChannel(channel)
-    }
-  }, [])
-
-  useEffect(() => {
     const promotersChannel = supabase
       .channel("public:promoters:manage")
       .on(


### PR DESCRIPTION
## Summary
- remove duplicate realtime subscriptions in promoter management pages

## Testing
- `npm test` *(fails: `jest` not found)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853a38a56708326b11bdb475faef3d1