### PR TITLE
Combine promoter manage subscriptions

### DIFF
--- a/app/[locale]/manage-promoters/page.tsx
+++ b/app/[locale]/manage-promoters/page.tsx
@@ -124,20 +124,6 @@ export default function ManagePromotersPage() {
 
   useEffect(() => {
     fetchPromotersWithContractCount()
-    const channel = supabase
-      .channel("public:promoters:manage")
-      .on(
-        "postgres_changes",
-        { event: "*", schema: "public", table: "promoters" },
-        () => fetchPromotersWithContractCount(),
-      )
-      .subscribe()
-    return () => {
-      supabase.removeChannel(channel)
-    }
-  }, [])
-
-  useEffect(() => {
     const promotersChannel = supabase
       .channel("public:promoters:manage")
       .on(

--- a/app/manage-promoters/page.tsx
+++ b/app/manage-promoters/page.tsx
@@ -124,20 +124,6 @@ export default function ManagePromotersPage() {
 
   useEffect(() => {
     fetchPromotersWithContractCount()
-    const channel = supabase
-      .channel("public:promoters:manage")
-      .on(
-        "postgres_changes",
-        { event: "*", schema: "public", table: "promoters" },
-        () => fetchPromotersWithContractCount(),
-      )
-      .subscribe()
-    return () => {
-      supabase.removeChannel(channel)
-    }
-  }, [])
-
-  useEffect(() => {
     const promotersChannel = supabase
       .channel("public:promoters:manage")
       .on(


### PR DESCRIPTION
## Summary
- consolidate duplicate Supabase subscriptions for promoter management
- keep contracts subscription

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853a4010bac83268c108c569c8590d6