### PR TITLE
Fix subscription effect dependencies

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -105,7 +105,7 @@ export default function DashboardPage() {
       supabase.removeChannel(promotersChannel)
       supabase.removeChannel(partiesChannel)
     }
-  }, [toast])
+  }, [])
 
   const summaryWidgetsData: SummaryWidgetData[] = [
     {

--- a/components/dashboard/audit-logs.tsx
+++ b/components/dashboard/audit-logs.tsx
@@ -52,6 +52,9 @@ export default function AuditLogs() {
 
   useEffect(() => {
     fetchAuditLogs()
+  }, [sortKey, sortDirection])
+
+  useEffect(() => {
     const channel = supabase
       .channel("public:audit_logs:feed") // Unique channel name
       .on("postgres_changes", { event: "INSERT", schema: "public", table: "audit_logs" }, (payload) => {
@@ -82,7 +85,7 @@ export default function AuditLogs() {
     return () => {
       supabase.removeChannel(channel)
     }
-  }, [sortKey, sortDirection, toast])
+  }, [])
 
   const filteredLogs = useMemo(() => {
     if (!logs) return []

--- a/components/dashboard/charts-section.tsx
+++ b/components/dashboard/charts-section.tsx
@@ -102,7 +102,7 @@ export default function ChartsSection() {
     return () => {
       supabase.removeChannel(contractsChartChannel)
     }
-  }, [toast])
+  }, [])
 
   if (loading) {
     return (

--- a/components/dashboard/contract-reports-table.tsx
+++ b/components/dashboard/contract-reports-table.tsx
@@ -59,7 +59,9 @@ export default function ContractReportsTable() {
 
   useEffect(() => {
     fetchContracts()
+  }, [sortKey, sortDirection])
 
+  useEffect(() => {
     // For views, Supabase Realtime listens to changes on the underlying tables.
     // So, we subscribe to `contracts`, `promoters`, and `parties`.
     const handleTableChange = (payload: any, tableName: string) => {
@@ -92,7 +94,7 @@ export default function ContractReportsTable() {
       supabase.removeChannel(promotersChannel)
       supabase.removeChannel(partiesChannel)
     }
-  }, [sortKey, sortDirection, toast]) // fetchContracts is stable, so not needed in deps if not changing itself
+  }, []) // subscribe once
 
   const filteredData = useMemo(() => {
     if (!contracts) return []

--- a/components/dashboard/notification-system.tsx
+++ b/components/dashboard/notification-system.tsx
@@ -103,7 +103,7 @@ export default function NotificationSystem() {
     return () => {
       supabase.removeChannel(channel)
     }
-  }, [toast])
+  }, [])
 
   return (
     <Card>

--- a/components/dashboard/review-panel.tsx
+++ b/components/dashboard/review-panel.tsx
@@ -67,7 +67,7 @@ export default function ReviewPanel() {
     return () => {
       supabase.removeChannel(channel)
     }
-  }, [toast])
+  }, [])
 
   const handleAction = async (itemId: string, action: "approve" | "reject" | "comment") => {
     toast({ title: `Action: ${action}`, description: `Processing item ${itemId}...` })


### PR DESCRIPTION
## Summary
- ensure dashboard KPI fetch runs once on mount
- run charts, review panel, and notification system subscriptions only once
- split audit logs and contract reports effects into fetch and subscribe steps

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853a4b75eb083268bc9f846f84112a2