### PR TITLE
Centralize document status helper

### DIFF
--- a/app/[locale]/manage-promoters/page.tsx
+++ b/app/[locale]/manage-promoters/page.tsx
@@ -16,56 +16,15 @@ import {
   UserIcon,
   FileTextIcon,
   Loader2,
-  AlertTriangleIcon,
-  ShieldCheckIcon,
-  ShieldAlertIcon,
   BriefcaseIcon,
   EyeIcon,
 } from "lucide-react"
 import { useToast } from "@/hooks/use-toast"
-import { format, parseISO, differenceInDays, isPast } from "date-fns"
+import { format } from "date-fns"
+import { getDocumentStatus } from "@/lib/document-status"
 import { Badge } from "@/components/ui/badge"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 
-// Helper function to determine document status
-const getDocumentStatus = (
-  expiryDate: string | null | undefined,
-): {
-  text: string
-  Icon: React.ElementType
-  colorClass: string
-  tooltip?: string
-} => {
-  if (!expiryDate) {
-    return { text: "No Date", Icon: AlertTriangleIcon, colorClass: "text-slate-500", tooltip: "Expiry date not set" }
-  }
-  const date = parseISO(expiryDate)
-  const today = new Date()
-  const daysUntilExpiry = differenceInDays(date, today)
-
-  if (isPast(date)) {
-    return {
-      text: "Expired",
-      Icon: ShieldAlertIcon,
-      colorClass: "text-red-500",
-      tooltip: `Expired on ${format(date, "MMM d, yyyy")}`,
-    }
-  }
-  if (daysUntilExpiry <= 30) {
-    return {
-      text: "Expires Soon",
-      Icon: ShieldAlertIcon,
-      colorClass: "text-orange-500",
-      tooltip: `Expires in ${daysUntilExpiry} day(s) on ${format(date, "MMM d, yyyy")}`,
-    }
-  }
-  return {
-    text: "Valid",
-    Icon: ShieldCheckIcon,
-    colorClass: "text-green-500",
-    tooltip: `Valid until ${format(date, "MMM d, yyyy")}`,
-  }
-}
 
 export default function ManagePromotersPage() {
   const [promoters, setPromoters] = useState<Promoter[]>([])

--- a/app/manage-promoters/[id]/page.tsx
+++ b/app/manage-promoters/[id]/page.tsx
@@ -16,58 +16,16 @@ import {
   BriefcaseIcon,
   ExternalLinkIcon,
   Loader2,
-  ShieldCheckIcon,
-  ShieldAlertIcon,
-  AlertTriangleIcon,
   EditIcon,
 } from "lucide-react"
-import { format, parseISO, differenceInDays, isPast } from "date-fns"
+import { format, parseISO, isPast } from "date-fns"
+import { getDocumentStatus } from "@/lib/document-status"
 import { Separator } from "@/components/ui/separator"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import LifecycleStatusIndicator from "@/components/lifecycle-status-indicator"
 
 interface PromoterDetails extends Promoter {
   contracts: ContractRecord<{ first_party?: Party; second_party?: Party }>[]
-}
-
-// Re-using helper from manage-promoters page
-const getDocumentStatus = (
-  expiryDate: string | null | undefined,
-): {
-  text: string
-  Icon: React.ElementType
-  colorClass: string
-  tooltip?: string
-} => {
-  if (!expiryDate) {
-    return { text: "No Date", Icon: AlertTriangleIcon, colorClass: "text-slate-500", tooltip: "Expiry date not set" }
-  }
-  const date = parseISO(expiryDate)
-  const today = new Date()
-  const daysUntilExpiry = differenceInDays(date, today)
-
-  if (isPast(date)) {
-    return {
-      text: "Expired",
-      Icon: ShieldAlertIcon,
-      colorClass: "text-red-500",
-      tooltip: `Expired on ${format(date, "MMM d, yyyy")}`,
-    }
-  }
-  if (daysUntilExpiry <= 30) {
-    return {
-      text: "Expires Soon",
-      Icon: ShieldAlertIcon,
-      colorClass: "text-orange-500",
-      tooltip: `Expires in ${daysUntilExpiry} day(s) on ${format(date, "MMM d, yyyy")}`,
-    }
-  }
-  return {
-    text: "Valid",
-    Icon: ShieldCheckIcon,
-    colorClass: "text-green-500",
-    tooltip: `Valid until ${format(date, "MMM d, yyyy")}`,
-  }
 }
 
 function DetailItem({

--- a/app/manage-promoters/page.tsx
+++ b/app/manage-promoters/page.tsx
@@ -16,56 +16,15 @@ import {
   UserIcon,
   FileTextIcon,
   Loader2,
-  AlertTriangleIcon,
-  ShieldCheckIcon,
-  ShieldAlertIcon,
   BriefcaseIcon,
   EyeIcon,
 } from "lucide-react"
 import { useToast } from "@/hooks/use-toast"
-import { format, parseISO, differenceInDays, isPast } from "date-fns"
+import { format } from "date-fns"
+import { getDocumentStatus } from "@/lib/document-status"
 import { Badge } from "@/components/ui/badge"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 
-// Helper function to determine document status
-const getDocumentStatus = (
-  expiryDate: string | null | undefined,
-): {
-  text: string
-  Icon: React.ElementType
-  colorClass: string
-  tooltip?: string
-} => {
-  if (!expiryDate) {
-    return { text: "No Date", Icon: AlertTriangleIcon, colorClass: "text-slate-500", tooltip: "Expiry date not set" }
-  }
-  const date = parseISO(expiryDate)
-  const today = new Date()
-  const daysUntilExpiry = differenceInDays(date, today)
-
-  if (isPast(date)) {
-    return {
-      text: "Expired",
-      Icon: ShieldAlertIcon,
-      colorClass: "text-red-500",
-      tooltip: `Expired on ${format(date, "MMM d, yyyy")}`,
-    }
-  }
-  if (daysUntilExpiry <= 30) {
-    return {
-      text: "Expires Soon",
-      Icon: ShieldAlertIcon,
-      colorClass: "text-orange-500",
-      tooltip: `Expires in ${daysUntilExpiry} day(s) on ${format(date, "MMM d, yyyy")}`,
-    }
-  }
-  return {
-    text: "Valid",
-    Icon: ShieldCheckIcon,
-    colorClass: "text-green-500",
-    tooltip: `Valid until ${format(date, "MMM d, yyyy")}`,
-  }
-}
 
 export default function ManagePromotersPage() {
   const [promoters, setPromoters] = useState<Promoter[]>([])

--- a/lib/document-status.ts
+++ b/lib/document-status.ts
@@ -1,0 +1,42 @@
+import type React from "react"
+import { format, parseISO, differenceInDays, isPast } from "date-fns"
+import { AlertTriangleIcon, ShieldCheckIcon, ShieldAlertIcon } from "lucide-react"
+
+export const getDocumentStatus = (
+  expiryDate: string | null | undefined,
+): {
+  text: string
+  Icon: React.ElementType
+  colorClass: string
+  tooltip?: string
+} => {
+  if (!expiryDate) {
+    return { text: "No Date", Icon: AlertTriangleIcon, colorClass: "text-slate-500", tooltip: "Expiry date not set" }
+  }
+  const date = parseISO(expiryDate)
+  const today = new Date()
+  const daysUntilExpiry = differenceInDays(date, today)
+
+  if (isPast(date)) {
+    return {
+      text: "Expired",
+      Icon: ShieldAlertIcon,
+      colorClass: "text-red-500",
+      tooltip: `Expired on ${format(date, "MMM d, yyyy")}`,
+    }
+  }
+  if (daysUntilExpiry <= 30) {
+    return {
+      text: "Expires Soon",
+      Icon: ShieldAlertIcon,
+      colorClass: "text-orange-500",
+      tooltip: `Expires in ${daysUntilExpiry} day(s) on ${format(date, "MMM d, yyyy")}`,
+    }
+  }
+  return {
+    text: "Valid",
+    Icon: ShieldCheckIcon,
+    colorClass: "text-green-500",
+    tooltip: `Valid until ${format(date, "MMM d, yyyy")}`,
+  }
+}


### PR DESCRIPTION
## Summary
- add `lib/document-status.ts` to host shared helper
- update promoter pages to import the helper instead of defining it locally

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853b58e05308326823e39094e26de96