### PR TITLE
Replace Link button wrappers with asChild

### DIFF
--- a/app/[locale]/contracts/page.tsx
+++ b/app/[locale]/contracts/page.tsx
@@ -225,9 +225,11 @@ export default function ContractsDashboardPage() {
                   </SelectContent>
                 </Select>
               </div>
-              <Link href="/[locale]/generate-contract" passHref locale={false}>
-                <Button>Create New Contract</Button>
-              </Link>
+              <Button asChild>
+                <Link href="/[locale]/generate-contract" locale={false}>
+                  Create New Contract
+                </Link>
+              </Button>
             </div>
 
             {filteredAndSortedContracts.length === 0 ? (
@@ -240,9 +242,11 @@ export default function ContractsDashboardPage() {
                     : "Get started by creating a new contract."}
                 </p>
                 {!(searchTerm || statusFilter !== "all") && (
-                  <Link href="/[locale]/generate-contract" passHref locale={false}>
-                    <Button className="mt-6">Create New Contract</Button>
-                  </Link>
+                  <Button asChild className="mt-6">
+                    <Link href="/[locale]/generate-contract" locale={false}>
+                      Create New Contract
+                    </Link>
+                  </Button>
                 )}
               </div>
             ) : (

--- a/app/[locale]/manage-parties/page.tsx
+++ b/app/[locale]/manage-parties/page.tsx
@@ -130,11 +130,11 @@ export default function ManagePartiesPage() {
           </Card>
         )}
         <div className="mt-8 text-center">
-          <Link href="/" passHref>
-            <Button variant="outline">
+          <Button asChild variant="outline">
+            <Link href="/">
               <ArrowLeftIcon className="mr-2 h-4 w-4" /> Back to Home
-            </Button>
-          </Link>
+            </Link>
+          </Button>
         </div>
       </div>
     </div>

--- a/app/[locale]/manage-promoters/page.tsx
+++ b/app/[locale]/manage-promoters/page.tsx
@@ -193,11 +193,11 @@ export default function ManagePromotersPage() {
         <div className="flex flex-col sm:flex-row justify-between items-center mb-8 gap-4">
           <h1 className="text-3xl font-bold text-slate-800 dark:text-slate-100">Manage Promoters</h1>
           <div className="flex gap-2">
-            <Link href="/" passHref>
-              <Button variant="outline">
+            <Button asChild variant="outline">
+              <Link href="/">
                 <ArrowLeftIcon className="mr-2 h-4 w-4" /> Back to Home
-              </Button>
-            </Link>
+              </Link>
+            </Button>
             <Button onClick={handleAddNew} className="bg-primary hover:bg-primary/90 text-primary-foreground">
               <PlusCircleIcon className="mr-2 h-5 w-5" />
               Add New Promoter
@@ -331,11 +331,11 @@ export default function ManagePromotersPage() {
                           </TableCell>
                           <TableCell className="px-4 py-3 text-right">
                             <div className="flex gap-2 justify-end">
-                              <Link href={`/manage-promoters/${promoter.id}`} passHref legacyBehavior>
-                                <Button variant="outline" size="sm" className="text-xs">
+                              <Button asChild variant="outline" size="sm" className="text-xs">
+                                <Link href={`/manage-promoters/${promoter.id}`}> 
                                   <EyeIcon className="mr-1 h-3.5 w-3.5" /> View
-                                </Button>
-                              </Link>
+                                </Link>
+                              </Button>
                               <Button
                                 variant="outline"
                                 size="sm"

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -114,11 +114,9 @@ export default function HomePage({ params }: { params: { locale: string } }) {
                     </Button>
                   </a>
                 ) : (
-                  <Link href={`/${params.locale}${action.href}`} passHref legacyBehavior>
-                    <Button variant={action.variant} className="w-full h-12 text-base font-semibold">
-                      {action.title}
-                    </Button>
-                  </Link>
+                  <Button asChild variant={action.variant} className="w-full h-12 text-base font-semibold">
+                    <Link href={`/${params.locale}${action.href}`}>{action.title}</Link>
+                  </Button>
                 )}
               </CardContent>
             </Card>

--- a/app/contracts/[id]/edit/page.tsx
+++ b/app/contracts/[id]/edit/page.tsx
@@ -19,18 +19,18 @@ export default function EditContractPage({ params }: { params: { id: string } })
           <p className="text-slate-600 dark:text-slate-300 mb-6">
             This page is under construction. Editing functionality will be implemented here.
           </p>
-          <Link href={`/contracts/${params.id}`} passHref className="inline-block mr-2">
-            <Button variant="outline">
+          <Button asChild variant="outline" className="inline-block mr-2">
+            <Link href={`/contracts/${params.id}`}> 
               <ArrowLeftIcon className="mr-2 h-4 w-4" />
               Back to Details
-            </Button>
-          </Link>
-          <Link href="/contracts" passHref className="inline-block">
-            <Button variant="secondary">
+            </Link>
+          </Button>
+          <Button asChild variant="secondary" className="inline-block">
+            <Link href="/contracts">
               <ArrowLeftIcon className="mr-2 h-4 w-4" />
               Back to Contracts List
-            </Button>
-          </Link>
+            </Link>
+          </Button>
         </CardContent>
       </Card>
     </div>

--- a/app/contracts/[id]/page.tsx
+++ b/app/contracts/[id]/page.tsx
@@ -124,12 +124,12 @@ export default async function ContractDetailPage({ params }: { params: { id: str
             <p className="text-card-foreground/80">
               The contract with ID <span className="font-mono text-primary">{params.id}</span> could not be found.
             </p>
-            <Link href="/contracts" passHref className="mt-6 inline-block">
-              <Button variant="outline">
+            <Button asChild variant="outline" className="mt-6 inline-block">
+              <Link href="/contracts">
                 <ArrowLeftIcon className="mr-2 h-4 w-4" />
                 Back to Contracts List
-              </Button>
-            </Link>
+              </Link>
+            </Button>
           </CardContent>
         </Card>
       </div>
@@ -145,12 +145,12 @@ export default async function ContractDetailPage({ params }: { params: { id: str
       <div className="max-w-6xl mx-auto">
         <div className="mb-8 flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
           <div>
-            <Link href="/contracts" passHref>
-              <Button variant="ghost" size="sm" className="text-muted-foreground hover:text-foreground">
-                <ArrowLeftIcon className="mr-2 h-4 w-4" />
-                Back to Contracts
-              </Button>
+          <Button asChild variant="ghost" size="sm" className="text-muted-foreground hover:text-foreground">
+            <Link href="/contracts">
+              <ArrowLeftIcon className="mr-2 h-4 w-4" />
+              Back to Contracts
             </Link>
+          </Button>
             <h1 className="text-3xl font-bold mt-2">Contract Overview</h1>
             <p className="text-muted-foreground">
               Reference ID:{" "}
@@ -159,12 +159,12 @@ export default async function ContractDetailPage({ params }: { params: { id: str
               </span>
             </p>
           </div>
-          <Link href={`/contracts/${contract.id}/edit`} passHref>
-            <Button>
+          <Button asChild>
+            <Link href={`/contracts/${contract.id}/edit`}>
               <EditIcon className="mr-2 h-4 w-4" />
               Edit Contract
-            </Button>
-          </Link>
+            </Link>
+          </Button>
         </div>
 
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 lg:gap-8">

--- a/app/contracts/page.tsx
+++ b/app/contracts/page.tsx
@@ -170,11 +170,11 @@ export default async function ContractsListPage({
           </CardHeader>
           <CardContent>
             <p>Could not fetch contracts: {error.message}</p>
-            <Link href="/" passHref>
-              <Button variant="outline" className="mt-4">
+            <Button asChild variant="outline" className="mt-4">
+              <Link href="/">
                 <ArrowLeftIcon className="mr-2 h-4 w-4" /> Back to Home
-              </Button>
-            </Link>
+              </Link>
+            </Button>
           </CardContent>
         </Card>
       </div>
@@ -188,11 +188,11 @@ export default async function ContractsListPage({
         {/* Wider max-width */}
         <div className="flex flex-col sm:flex-row justify-between items-center mb-8 gap-4">
           <h1 className="text-3xl font-bold text-slate-800 dark:text-slate-100">Contract Management</h1>
-          <Link href="/" passHref>
-            <Button variant="outline" className="w-full sm:w-auto">
+          <Button asChild variant="outline" className="w-full sm:w-auto">
+            <Link href="/">
               <ArrowLeftIcon className="mr-2 h-4 w-4" /> Back to Home
-            </Button>
-          </Link>
+            </Link>
+          </Button>
         </div>
         {/* Summary Cards - Refined Style */}
         <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4 mb-8">
@@ -355,24 +355,30 @@ export default async function ContractsListPage({
                   {Math.min(ITEMS_PER_PAGE * currentPage, count)} of {count} contracts
                 </span>
                 <div className="flex items-center space-x-2">
-                  <Link
-                    href={`/contracts?page=${currentPage - 1}${generationStatusFilter ? `&status=${generationStatusFilter}` : ""}${searchQuery ? `&q=${searchQuery}` : ""}`}
-                    passHref
-                    legacyBehavior
+                  <Button
+                    asChild
+                    variant="outline"
+                    size="sm"
+                    disabled={currentPage <= 1}
                   >
-                    <Button variant="outline" size="sm" disabled={currentPage <= 1}>
+                    <Link
+                      href={`/contracts?page=${currentPage - 1}${generationStatusFilter ? `&status=${generationStatusFilter}` : ""}${searchQuery ? `&q=${searchQuery}` : ""}`}
+                    >
                       Previous
-                    </Button>
-                  </Link>
-                  <Link
-                    href={`/contracts?page=${currentPage + 1}${generationStatusFilter ? `&status=${generationStatusFilter}` : ""}${searchQuery ? `&q=${searchQuery}` : ""}`}
-                    passHref
-                    legacyBehavior
+                    </Link>
+                  </Button>
+                  <Button
+                    asChild
+                    variant="outline"
+                    size="sm"
+                    disabled={currentPage >= totalPages}
                   >
-                    <Button variant="outline" size="sm" disabled={currentPage >= totalPages}>
+                    <Link
+                      href={`/contracts?page=${currentPage + 1}${generationStatusFilter ? `&status=${generationStatusFilter}` : ""}${searchQuery ? `&q=${searchQuery}` : ""}`}
+                    >
                       Next
-                    </Button>
-                  </Link>
+                    </Link>
+                  </Button>
                 </div>
               </div>
             )}

--- a/app/dashboard/contracts/page.tsx
+++ b/app/dashboard/contracts/page.tsx
@@ -11,12 +11,12 @@ export default function ContractsPage() {
       <div className="space-y-6">
         <div className="flex justify-between items-center">
           <h1 className="text-2xl font-semibold">Manage Contracts / إدارة العقود</h1>
-          <Link href="/generate-contract" passHref>
-            <Button>
+          <Button asChild>
+            <Link href="/generate-contract">
               <FilePlus2Icon className="mr-2 h-5 w-5" />
               Generate New Contract
-            </Button>
-          </Link>
+            </Link>
+          </Button>
         </div>
         <ContractReportsTable />
         {/* Additional contract management features can be added here */}

--- a/app/manage-parties/page.tsx
+++ b/app/manage-parties/page.tsx
@@ -130,11 +130,11 @@ export default function ManagePartiesPage() {
           </Card>
         )}
         <div className="mt-8 text-center">
-          <Link href="/" passHref>
-            <Button variant="outline">
+          <Button asChild variant="outline">
+            <Link href="/">
               <ArrowLeftIcon className="mr-2 h-4 w-4" /> Back to Home
-            </Button>
-          </Link>
+            </Link>
+          </Button>
         </div>
       </div>
     </div>

--- a/app/manage-promoters/[id]/edit/page.tsx
+++ b/app/manage-promoters/[id]/edit/page.tsx
@@ -24,18 +24,18 @@ export default function EditPromoterPage() {
           <p className="text-slate-600 dark:text-slate-300 mb-6">
             Editing functionality for promoters will be implemented here.
           </p>
-          <Link href={`/manage-promoters/${promoterId}`} legacyBehavior passHref>
-            <Button variant="outline" className="mr-2">
+          <Button asChild variant="outline" className="mr-2">
+            <Link href={`/manage-promoters/${promoterId}`}> 
               <ArrowLeftIcon className="mr-2 h-4 w-4" />
               Back to Promoter Details
-            </Button>
-          </Link>
-          <Link href="/manage-promoters" legacyBehavior passHref>
-            <Button variant="secondary">
+            </Link>
+          </Button>
+          <Button asChild variant="secondary">
+            <Link href="/manage-promoters">
               <ArrowLeftIcon className="mr-2 h-4 w-4" />
               Back to Promoter List
-            </Button>
-          </Link>
+            </Link>
+          </Button>
         </CardContent>
       </Card>
     </div>

--- a/app/manage-promoters/[id]/page.tsx
+++ b/app/manage-promoters/[id]/page.tsx
@@ -211,12 +211,12 @@ export default function PromoterDetailPage() {
               {promoterDetails.name_ar}
             </p>
           </div>
-          <Link href={`/manage-promoters/${promoterId}/edit`} passHref legacyBehavior>
-            <Button>
+          <Button asChild>
+            <Link href={`/manage-promoters/${promoterId}/edit`}>
               <EditIcon className="mr-2 h-4 w-4" />
               Edit Promoter
-            </Button>
-          </Link>
+            </Link>
+          </Button>
         </div>
 
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 lg:gap-8">

--- a/app/manage-promoters/page.tsx
+++ b/app/manage-promoters/page.tsx
@@ -193,11 +193,11 @@ export default function ManagePromotersPage() {
         <div className="flex flex-col sm:flex-row justify-between items-center mb-8 gap-4">
           <h1 className="text-3xl font-bold text-slate-800 dark:text-slate-100">Manage Promoters</h1>
           <div className="flex gap-2">
-            <Link href="/" passHref>
-              <Button variant="outline">
+            <Button asChild variant="outline">
+              <Link href="/">
                 <ArrowLeftIcon className="mr-2 h-4 w-4" /> Back to Home
-              </Button>
-            </Link>
+              </Link>
+            </Button>
             <Button onClick={handleAddNew} className="bg-primary hover:bg-primary/90 text-primary-foreground">
               <PlusCircleIcon className="mr-2 h-5 w-5" />
               Add New Promoter
@@ -331,11 +331,11 @@ export default function ManagePromotersPage() {
                           </TableCell>
                           <TableCell className="px-4 py-3 text-right">
                             <div className="flex gap-2 justify-end">
-                              <Link href={`/manage-promoters/${promoter.id}`} passHref legacyBehavior>
-                                <Button variant="outline" size="sm" className="text-xs">
+                              <Button asChild variant="outline" size="sm" className="text-xs">
+                                <Link href={`/manage-promoters/${promoter.id}`}> 
                                   <EyeIcon className="mr-1 h-3.5 w-3.5" /> View
-                                </Button>
-                              </Link>
+                                </Link>
+                              </Button>
                               <Button
                                 variant="outline"
                                 size="sm"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,36 +14,36 @@ export default function HomePage() {
         </CardHeader>
         <AuthStatus />
         <CardContent className="space-y-4 pt-6">
-          <Link href="/generate-contract" passHref legacyBehavior>
-            <Button variant="default" className="w-full justify-start">
+          <Button asChild variant="default" className="w-full justify-start">
+            <Link href="/generate-contract">
               <FilePlus2Icon className="mr-2 h-5 w-5" />
               Generate New Contract
-            </Button>
-          </Link>
-          <Link href="/contracts" passHref legacyBehavior>
-            <Button variant="secondary" className="w-full justify-start">
+            </Link>
+          </Button>
+          <Button asChild variant="secondary" className="w-full justify-start">
+            <Link href="/contracts">
               <History className="mr-2 h-5 w-5" />
               View Contract History & Status
-            </Button>
-          </Link>
-          <Link href="/manage-promoters" passHref legacyBehavior>
-            <Button variant="outline" className="w-full justify-start">
+            </Link>
+          </Button>
+          <Button asChild variant="outline" className="w-full justify-start">
+            <Link href="/manage-promoters">
               <UsersIcon className="mr-2 h-5 w-5" />
               Manage Promoters
-            </Button>
-          </Link>
-          <Link href="/manage-parties" passHref legacyBehavior>
-            <Button variant="outline" className="w-full justify-start">
+            </Link>
+          </Button>
+          <Button asChild variant="outline" className="w-full justify-start">
+            <Link href="/manage-parties">
               <BuildingIcon className="mr-2 h-5 w-5" />
               Manage Parties
-            </Button>
-          </Link>
-          <Link href="/request-contract" passHref legacyBehavior>
-            <Button variant="outline" className="w-full justify-start">
+            </Link>
+          </Button>
+          <Button asChild variant="outline" className="w-full justify-start">
+            <Link href="/request-contract">
               <FileTextIcon className="mr-2 h-5 w-5" />
               Request New Contract (Manual Form)
-            </Button>
-          </Link>
+            </Link>
+          </Button>
           <a href="/index.html" target="_blank" rel="noopener noreferrer" className="block">
             <Button variant="outline" className="w-full justify-start">
               <ExternalLinkIcon className="mr-2 h-5 w-5" />


### PR DESCRIPTION
## Summary
- refactor `Link` wrapped buttons across the app
- use `<Button asChild>` pattern
- drop `legacyBehavior` and `passHref` props

## Testing
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853b597dc98832687be5b81d38db34d