### PR TITLE
Unify promoter notification column names

### DIFF
--- a/components/promoter-form.tsx
+++ b/components/promoter-form.tsx
@@ -86,20 +86,20 @@ export default function PromoterForm({ promoterToEdit, onFormSubmit }: PromoterF
       work_location: "",
       status: "active",
       contract_valid_until: null,
-      notify_before_id_expiry_days: 30,
-      notify_before_passport_expiry_days: 90,
-      notify_before_contract_expiry_days: 30,
+      notify_days_before_id_expiry: 30,
+      notify_days_before_passport_expiry: 90,
+      notify_days_before_contract_expiry: 30,
       notes: "",
     },
   })
 
   // Watch relevant fields for expiry alerts
   const idCardExpiryDate = useWatch({ control: form.control, name: "id_card_expiry_date" })
-  const notifyIdDays = useWatch({ control: form.control, name: "notify_before_id_expiry_days" })
+  const notifyIdDays = useWatch({ control: form.control, name: "notify_days_before_id_expiry" })
   const passportExpiryDate = useWatch({ control: form.control, name: "passport_expiry_date" })
-  const notifyPassportDays = useWatch({ control: form.control, name: "notify_before_passport_expiry_days" })
+  const notifyPassportDays = useWatch({ control: form.control, name: "notify_days_before_passport_expiry" })
   const contractValidUntil = useWatch({ control: form.control, name: "contract_valid_until" })
-  const notifyContractDays = useWatch({ control: form.control, name: "notify_before_contract_expiry_days" })
+  const notifyContractDays = useWatch({ control: form.control, name: "notify_days_before_contract_expiry" })
 
   const idCardAlert = getExpiryAlert(idCardExpiryDate, notifyIdDays, "ID Card")
   const passportAlert = getExpiryAlert(passportExpiryDate, notifyPassportDays, "Passport")
@@ -127,18 +127,18 @@ export default function PromoterForm({ promoterToEdit, onFormSubmit }: PromoterF
         contract_valid_until: promoterToEdit.contract_valid_until
           ? parseISO(promoterToEdit.contract_valid_until)
           : null,
-        notify_before_id_expiry_days: promoterToEdit.notify_before_id_expiry_days ?? 30,
-        notify_before_passport_expiry_days: promoterToEdit.notify_before_passport_expiry_days ?? 90,
-        notify_before_contract_expiry_days: promoterToEdit.notify_before_contract_expiry_days ?? 30,
+        notify_days_before_id_expiry: promoterToEdit.notify_days_before_id_expiry ?? 30,
+        notify_days_before_passport_expiry: promoterToEdit.notify_days_before_passport_expiry ?? 90,
+        notify_days_before_contract_expiry: promoterToEdit.notify_days_before_contract_expiry ?? 30,
         notes: promoterToEdit.notes || "",
       })
     } else {
       form.reset({
         ...form.formState.defaultValues,
         status: "active",
-        notify_before_id_expiry_days: 30,
-        notify_before_passport_expiry_days: 90,
-        notify_before_contract_expiry_days: 30,
+        notify_days_before_id_expiry: 30,
+        notify_days_before_passport_expiry: 90,
+        notify_days_before_contract_expiry: 30,
       })
     }
   }, [promoterToEdit, form])
@@ -203,9 +203,9 @@ export default function PromoterForm({ promoterToEdit, onFormSubmit }: PromoterF
         work_location: values.work_location,
         status: values.status,
         contract_valid_until: values.contract_valid_until ? format(values.contract_valid_until, "yyyy-MM-dd") : null,
-        notify_before_id_expiry_days: values.notify_before_id_expiry_days,
-        notify_before_passport_expiry_days: values.notify_before_passport_expiry_days,
-        notify_before_contract_expiry_days: values.notify_before_contract_expiry_days,
+        notify_days_before_id_expiry: values.notify_days_before_id_expiry,
+        notify_days_before_passport_expiry: values.notify_days_before_passport_expiry,
+        notify_days_before_contract_expiry: values.notify_days_before_contract_expiry,
         notes: values.notes,
       }
 
@@ -528,7 +528,7 @@ export default function PromoterForm({ promoterToEdit, onFormSubmit }: PromoterF
             <div className="grid grid-cols-1 md:grid-cols-3 gap-x-6 gap-y-8">
               <FormField
                 control={form.control}
-                name="notify_before_id_expiry_days"
+                name="notify_days_before_id_expiry"
                 render={({ field }) => (
                   <FormItem>
                     <ShadcnFormLabel>ID Expiry Alert (Days) / تنبيه انتهاء البطاقة (أيام)</ShadcnFormLabel>
@@ -550,7 +550,7 @@ export default function PromoterForm({ promoterToEdit, onFormSubmit }: PromoterF
               />
               <FormField
                 control={form.control}
-                name="notify_before_passport_expiry_days"
+                name="notify_days_before_passport_expiry"
                 render={({ field }) => (
                   <FormItem>
                     <ShadcnFormLabel>Passport Expiry Alert (Days) / تنبيه انتهاء الجواز (أيام)</ShadcnFormLabel>
@@ -572,7 +572,7 @@ export default function PromoterForm({ promoterToEdit, onFormSubmit }: PromoterF
               />
               <FormField
                 control={form.control}
-                name="notify_before_contract_expiry_days"
+                name="notify_days_before_contract_expiry"
                 render={({ field }) => (
                   <FormItem>
                     <ShadcnFormLabel>Contract Expiry Alert (Days) / تنبيه انتهاء العقد (أيام)</ShadcnFormLabel>

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -22,9 +22,9 @@ export interface Promoter {
   contract_valid_until?: string | null
   id_card_expiry_date?: string | null
   passport_expiry_date?: string | null
-  notify_before_id_expiry_days?: number | null
-  notify_before_passport_expiry_days?: number | null
-  notify_before_contract_expiry_days?: number | null
+  notify_days_before_id_expiry?: number | null
+  notify_days_before_passport_expiry?: number | null
+  notify_days_before_contract_expiry?: number | null
   notes?: string | null
   created_at?: string | null
   active_contracts_count?: number

--- a/scripts/001_create_promoters_table.sql
+++ b/scripts/001_create_promoters_table.sql
@@ -13,9 +13,9 @@ CREATE TABLE IF NOT EXISTS promoters (
     contract_valid_until DATE,
     id_card_expiry_date DATE,
     passport_expiry_date DATE,
-    notify_before_id_expiry_days INTEGER DEFAULT 30,
-    notify_before_passport_expiry_days INTEGER DEFAULT 90,
-    notify_before_contract_expiry_days INTEGER DEFAULT 30,
+    notify_days_before_id_expiry INTEGER DEFAULT 30,
+    notify_days_before_passport_expiry INTEGER DEFAULT 90,
+    notify_days_before_contract_expiry INTEGER DEFAULT 30,
     notes TEXT,
     created_at TIMESTAMPTZ DEFAULT NOW()
 );

--- a/scripts/003_alter_promoters_refactor.sql
+++ b/scripts/003_alter_promoters_refactor.sql
@@ -4,6 +4,35 @@
 
 DO $$
 BEGIN
+    -- Rename legacy notification columns if present
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name='promoters' AND column_name='notify_before_id_expiry_days'
+    ) THEN
+        IF NOT EXISTS (
+            SELECT 1 FROM information_schema.columns
+            WHERE table_name='promoters' AND column_name='notify_days_before_id_expiry'
+        ) THEN
+            ALTER TABLE promoters RENAME COLUMN notify_before_id_expiry_days TO notify_days_before_id_expiry;
+        ELSE
+            ALTER TABLE promoters DROP COLUMN notify_before_id_expiry_days;
+        END IF;
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name='promoters' AND column_name='notify_before_passport_expiry_days'
+    ) THEN
+        IF NOT EXISTS (
+            SELECT 1 FROM information_schema.columns
+            WHERE table_name='promoters' AND column_name='notify_days_before_passport_expiry'
+        ) THEN
+            ALTER TABLE promoters RENAME COLUMN notify_before_passport_expiry_days TO notify_days_before_passport_expiry;
+        ELSE
+            ALTER TABLE promoters DROP COLUMN notify_before_passport_expiry_days;
+        END IF;
+    END IF;
+
     -- Add notify_days_before_id_expiry
     IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='promoters' AND column_name='notify_days_before_id_expiry') THEN
         ALTER TABLE promoters ADD COLUMN notify_days_before_id_expiry INTEGER DEFAULT 30;


### PR DESCRIPTION
## Summary
- align promoter notification column names to `notify_days_before_*`
- rename columns in migration with fallback for legacy columns
- update TypeScript types and promoter form field names

## Testing
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853e041c8608326bdfe99102f6e41ca