### PR TITLE
Fix typed supabase client

### DIFF
--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@supabase/supabase-js"
+import type { Database } from "@/types/supabase"
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
@@ -7,4 +8,4 @@ if (!supabaseUrl || !supabaseAnonKey) {
   throw new Error("Supabase URL or Anon Key is missing. Check your environment variables.")
 }
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey)
+export const supabase = createClient<Database>(supabaseUrl, supabaseAnonKey)


### PR DESCRIPTION
## Summary
- use generated Database types for the browser supabase client

## Testing
- `pnpm test` *(fails: jest not found)*
- `pnpm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853e05012a883268ecd9bf14f2f682c