### PR TITLE
Improve promoter fetch error logging

### DIFF
--- a/hooks/use-promoters.ts
+++ b/hooks/use-promoters.ts
@@ -12,6 +12,8 @@ const fetchPromoters = async (): Promise<Promoter[]> => {
     .order("name_en", { ascending: true })
   if (error) {
     console.error("Error fetching promoters:", error)
+    // Log the complete error object for easier debugging
+    console.error(error)
     toast.error("Error loading promoters", { description: error.message })
     throw new Error(error.message)
   }
@@ -50,5 +52,5 @@ export const usePromoters = () => {
     }
   }, [queryClient, queryKey])
 
-  return queryResult
+  return { ...queryResult, errorMessage: queryResult.error?.message }
 }


### PR DESCRIPTION
## Summary
- log the complete error object in `use-promoters`
- expose the error message from the `usePromoters` hook

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853e051a7788326b1b2aee51cfafc34