### PR TITLE
Fix promoters hook subscription

### DIFF
--- a/hooks/use-promoters.ts
+++ b/hooks/use-promoters.ts
@@ -1,5 +1,5 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query"
-import { useEffect } from "react"
+import { useEffect, useMemo } from "react"
 import { supabase } from "@/lib/supabase"
 import { devLog } from "@/lib/dev-log"
 import { toast } from "sonner"
@@ -20,7 +20,7 @@ const fetchPromoters = async (): Promise<Promoter[]> => {
 
 export const usePromoters = () => {
   const queryClient = useQueryClient()
-  const queryKey = ["promoters"]
+  const queryKey = useMemo(() => ["promoters"], [])
 
   const queryResult = useQuery<Promoter[], Error>({
     queryKey,
@@ -48,7 +48,7 @@ export const usePromoters = () => {
     return () => {
       supabase.removeChannel(channel)
     }
-  }, [queryClient, queryKey])
+  }, [queryClient])
 
   return queryResult
 }


### PR DESCRIPTION
## Summary
- memoize the `queryKey` for `usePromoters`
- reduce `useEffect` dependencies to keep subscription stable

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853e0614f308326983a695f45c5831f