### PR TITLE
Handle unauthenticated promoters query

### DIFF
--- a/hooks/use-promoters.test.ts
+++ b/hooks/use-promoters.test.ts
@@ -1,0 +1,61 @@
+import { render, waitFor } from "@testing-library/react"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { usePromoters } from "@/hooks/use-promoters"
+
+const pushMock = jest.fn()
+const toastMock = jest.fn()
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: pushMock,
+  }),
+  usePathname: jest.fn(() => "/"),
+  useSearchParams: jest.fn(() => new URLSearchParams()),
+}))
+
+jest.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({
+    toast: toastMock,
+  }),
+}))
+
+const getSessionMock = jest.fn()
+
+jest.mock("@/lib/supabase", () => ({
+  supabase: {
+    auth: { getSession: getSessionMock },
+    from: jest.fn(),
+    channel: jest.fn(() => ({ on: jest.fn().mockReturnThis(), subscribe: jest.fn(() => "chan") })),
+    removeChannel: jest.fn(),
+  },
+}))
+
+describe("usePromoters", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("redirects and shows toast when unauthenticated", async () => {
+    getSessionMock.mockResolvedValue({ data: { session: null }, error: null })
+
+    const queryClient = new QueryClient()
+
+    const TestComponent = () => {
+      usePromoters()
+      return null
+    }
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <TestComponent />
+      </QueryClientProvider>,
+    )
+
+    await waitFor(() => {
+      expect(pushMock).toHaveBeenCalledWith("/login")
+    })
+    expect(toastMock).toHaveBeenCalledWith(
+      expect.objectContaining({ variant: "destructive" }),
+    )
+  })
+})

--- a/hooks/use-promoters.ts
+++ b/hooks/use-promoters.ts
@@ -2,19 +2,34 @@ import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { useEffect, useMemo } from "react"
 import { supabase } from "@/lib/supabase"
 import { devLog } from "@/lib/dev-log"
-import { toast } from "sonner"
+import { useToast } from "@/hooks/use-toast"
+import { useRouter } from "next/navigation"
 import type { Promoter } from "@/types/custom"
 
 const fetchPromoters = async (): Promise<Promoter[]> => {
+  const {
+    data: { session },
+    error: sessionError,
+  } = await supabase.auth.getSession()
+
+  if (sessionError) {
+    console.error("Error fetching session:", sessionError)
+    throw new Error(sessionError.message)
+  }
+
+  if (!session) {
+    throw new Error("Not authenticated")
+  }
+
   const { data, error } = await supabase
     .from("promoters")
     .select("*")
     .order("name_en", { ascending: true })
+
   if (error) {
     console.error("Error fetching promoters:", error)
     // Log the complete error object for easier debugging
     console.error(error)
-    toast.error("Error loading promoters", { description: error.message })
     throw new Error(error.message)
   }
   return data || []
@@ -23,11 +38,21 @@ const fetchPromoters = async (): Promise<Promoter[]> => {
 export const usePromoters = () => {
   const queryClient = useQueryClient()
   const queryKey = useMemo(() => ["promoters"], [])
+  const { toast } = useToast()
+  const router = useRouter()
 
   const queryResult = useQuery<Promoter[], Error>({
     queryKey,
     queryFn: fetchPromoters,
     staleTime: 1000 * 60 * 5,
+    onError: (error) => {
+      toast({
+        title: "Authentication Required",
+        description: error.message,
+        variant: "destructive",
+      })
+      router.push("/login")
+    },
   })
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- check user session before querying promoters
- surface authentication errors via React Query
- show destructive toast and redirect to login when unauthenticated
- add unit test for authentication redirect

## Testing
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853f98e6f4c83268822f7999c92c027