### PR TITLE
Fix promoters subscription dependencies

### DIFF
--- a/hooks/use-promoters.ts
+++ b/hooks/use-promoters.ts
@@ -50,7 +50,7 @@ export const usePromoters = () => {
     return () => {
       supabase.removeChannel(channel)
     }
-  }, [queryClient])
+  }, [queryClient, queryKey])
 
   return { ...queryResult, errorMessage: queryResult.error?.message }
 }


### PR DESCRIPTION
## Summary
- ensure the promoters realtime subscription reacts to query key changes

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853f9902a8c8326a364013a65e44c70