### PR TITLE
Fix toast listener effect

### DIFF
--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -182,7 +182,7 @@ function useToast() {
         listeners.splice(index, 1)
       }
     }
-  }, [state])
+  }, [])
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- only register toast listener once when `useToast` mounts

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853fa6c6db08326b669657d6671aecb