### PR TITLE
Fix useEffect deps for promoters

### DIFF
--- a/hooks/use-promoters.ts
+++ b/hooks/use-promoters.ts
@@ -50,7 +50,7 @@ export const usePromoters = () => {
     return () => {
       supabase.removeChannel(channel)
     }
-  }, [queryClient])
+  }, [queryClient, queryKey])
 
   return { ...queryResult, errorMessage: queryResult.error?.message }
 }


### PR DESCRIPTION
## Summary
- ensure realtime updates use current query key by including `queryKey` dependency

## Testing
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853fa8a5a988326b12a99f71b78faf6