### PR TITLE
Fix Next.js build strict settings

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,10 +2,10 @@
 const nextConfig = {
   reactStrictMode: true,
   eslint: {
-    ignoreDuringBuilds: true,
+    ignoreDuringBuilds: false,
   },
   typescript: {
-    ignoreBuildErrors: true,
+    ignoreBuildErrors: false,
   },
   images: {
     unoptimized: true, // Useful for static exports or if image optimization is handled elsewhere


### PR DESCRIPTION
## Summary
- enforce errors during `next build` by disabling error ignoring settings

## Testing
- `pnpm exec next lint` *(fails: Command "next" not found)*
- `pnpm exec tsc --noEmit` *(fails: TS errors, also installation impossible without internet)*

------
https://chatgpt.com/codex/tasks/task_e_6853fcf025d48326ad01566103983378