### PR TITLE
Fix promoter query retry behavior

### DIFF
--- a/hooks/use-promoters.ts
+++ b/hooks/use-promoters.ts
@@ -45,6 +45,7 @@ export const usePromoters = () => {
     queryKey,
     queryFn: fetchPromoters,
     staleTime: 1000 * 60 * 5,
+    retry: false,
     onError: (error) => {
       toast({
         title: "Authentication Required",


### PR DESCRIPTION
## Summary
- avoid retrying the promoters query when authentication fails

## Testing
- `pnpm install` *(fails: Forbidden 403 from registry)*
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853fde6ec1883269600d2e60dcce8b0