### PR TITLE
Replace Sonner with custom toast hook

### DIFF
--- a/components/contract-generator-form.test.tsx
+++ b/components/contract-generator-form.test.tsx
@@ -2,7 +2,11 @@ import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import ContractGeneratorForm from "./contract-generator-form"
-import { toast } from "sonner"
+
+const mockToast = jest.fn()
+jest.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: mockToast }),
+}))
 
 import { useParties } from "@/hooks/use-parties"
 import { usePromoters } from "@/hooks/use-promoters"
@@ -118,6 +122,6 @@ describe("ContractGeneratorForm", () => {
       "/api/contracts",
       expect.objectContaining({ method: "POST" }),
     )
-    expect((toast as any).success).toHaveBeenCalled()
+    expect(mockToast).toHaveBeenCalled()
   })
 })

--- a/components/contract-generator-form.tsx
+++ b/components/contract-generator-form.tsx
@@ -6,7 +6,7 @@ import { useEffect, useState } from "react"
 import { useForm, useWatch } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
-import { toast } from "sonner"
+import { useToast } from "@/hooks/use-toast"
 import { format } from "date-fns"
 
 import { contractGeneratorSchema, type ContractGeneratorFormData } from "@/lib/schema-generator"
@@ -30,6 +30,7 @@ const sectionVariants = {
 
 export default function ContractGeneratorForm() {
   const queryClient = useQueryClient()
+  const { toast } = useToast()
 
   // Fetch parties using the React Query hook
   const {
@@ -61,17 +62,27 @@ export default function ContractGeneratorForm() {
 
   useEffect(() => {
     if (employerPartiesError) {
-      toast.error("Error loading Employer parties", { description: employerPartiesError.message })
+      toast({
+        title: "Error loading Employer parties",
+        description: employerPartiesError.message,
+        variant: "destructive",
+      })
     }
     if (clientPartiesError) {
-      toast.error("Error loading Client parties", { description: clientPartiesError.message })
+      toast({
+        title: "Error loading Client parties",
+        description: clientPartiesError.message,
+        variant: "destructive",
+      })
     }
   }, [employerPartiesError, clientPartiesError])
 
   useEffect(() => {
     if (promotersError) {
-      toast.error("Error loading promoters", {
+      toast({
+        title: "Error loading promoters",
         description: promotersError.message,
+        variant: "destructive",
       })
     }
   }, [promotersError])
@@ -137,15 +148,18 @@ export default function ContractGeneratorForm() {
       return response.json()
     },
     onSuccess: (data) => {
-      toast.success("Contract Created!", {
+      toast({
+        title: "Contract Created!",
         description: `PDF: ${data.contract.pdf_url || "Pending generation."}`,
       })
       form.reset()
       queryClient.invalidateQueries({ queryKey: ["contracts"] })
     },
     onError: (error: any) => {
-      toast.error("Creation Failed", {
+      toast({
+        title: "Creation Failed",
         description: error.message || "An unexpected error occurred.",
+        variant: "destructive",
       })
     },
   })

--- a/hooks/use-parties.ts
+++ b/hooks/use-parties.ts
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query"
 import { supabase } from "@/lib/supabase" // Your Supabase client instance
 import type { Database } from "@/types/supabase" // Assuming generated Supabase types
-import { toast } from "sonner" // For error notifications
+import { useToast } from "@/hooks/use-toast"
 
 // Define the structure of a Party based on your select query
 export type Party = Pick<Database["public"]["Tables"]["parties"]["Row"], "id" | "name_en" | "name_ar" | "crn" | "type">
@@ -17,16 +17,23 @@ const fetchParties = async (partyType?: "Employer" | "Client"): Promise<Party[]>
 
   if (error) {
     console.error("Error fetching parties:", error)
-    toast.error("Error loading parties", { description: error.message })
     throw new Error(error.message) // React Query will handle this error
   }
   return data || []
 }
 
 export const useParties = (partyType?: "Employer" | "Client") => {
+  const { toast } = useToast()
   return useQuery<Party[], Error>({
     queryKey: ["parties", partyType || "all"], // Unique query key based on type
     queryFn: () => fetchParties(partyType),
     staleTime: 1000 * 60 * 5, // Cache data for 5 minutes
+    onError: (error) => {
+      toast({
+        title: "Error loading parties",
+        description: error.message,
+        variant: "destructive",
+      })
+    },
   })
 }

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -15,18 +15,6 @@ jest.mock("next/navigation", () => ({
   useSearchParams: jest.fn(() => new URLSearchParams()),
 }))
 
-// Mock sonner's useToast or the specific toast function
-jest.mock("sonner", () => ({
-  toast: {
-    success: jest.fn(),
-    error: jest.fn(),
-    info: jest.fn(),
-    warning: jest.fn(),
-    loading: jest.fn(),
-    dismiss: jest.fn(),
-  },
-}))
-
 // Mock useToast if not already globally mocked in your tests
 jest.mock("@/hooks/use-toast", () => ({
   useToast: () => ({

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "react-hook-form": "latest",
     "react-resizable-panels": "^2.1.7",
     "recharts": "latest",
-    "sonner": "latest",
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
     "use-debounce": "latest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,9 +161,6 @@ importers:
       recharts:
         specifier: latest
         version: 2.15.3(react-dom@18.0.0(react@18.0.0))(react@18.0.0)
-      sonner:
-        specifier: latest
-        version: 2.0.5(react-dom@18.0.0(react@18.0.0))(react@18.0.0)
       tailwind-merge:
         specifier: ^2.5.5
         version: 2.5.5
@@ -2466,11 +2463,6 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
-  sonner@2.0.5:
-    resolution: {integrity: sha512-YwbHQO6cSso3HBXlbCkgrgzDNIhws14r4MO87Ofy+cV2X7ES4pOoAK3+veSmVTvqNx1BWUxlhPmZzP00Crk2aQ==}
-    peerDependencies:
-      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -5025,10 +5017,6 @@ snapshots:
 
   slash@3.0.0: {}
 
-  sonner@2.0.5(react-dom@18.0.0(react@18.0.0))(react@18.0.0):
-    dependencies:
-      react: 18.0.0
-      react-dom: 18.0.0(react@18.0.0)
 
   source-map-js@1.2.1: {}
 


### PR DESCRIPTION
## Summary
- switch `ContractGeneratorForm` to use `useToast`
- update toast invocations to object style
- use `useToast` within `useParties` hook
- mock `useToast` in tests and remove Sonner mocks
- drop `sonner` dependency

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853fde0d9bc83269bee20820b48a469