### PR TITLE
Update promoter error handling

### DIFF
--- a/hooks/use-promoters.ts
+++ b/hooks/use-promoters.ts
@@ -46,12 +46,20 @@ export const usePromoters = () => {
     queryFn: fetchPromoters,
     staleTime: 1000 * 60 * 5,
     onError: (error) => {
-      toast({
-        title: "Authentication Required",
-        description: error.message,
-        variant: "destructive",
-      })
-      router.push("/login")
+      if (error.message === "Not authenticated") {
+        toast({
+          title: "Authentication Required",
+          description: error.message,
+          variant: "destructive",
+        })
+        router.push("/login")
+      } else {
+        toast({
+          title: "Error loading promoters",
+          description: error.message,
+          variant: "destructive",
+        })
+      }
     },
   })
 


### PR DESCRIPTION
## Summary
- update promoter fetch error handling
- test unauthenticated and general promoter fetch errors

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853fdee442c83269c7faf6b11c21e7c