### PR TITLE
Add toast to contract deletion errors

### DIFF
--- a/hooks/use-contracts.ts
+++ b/hooks/use-contracts.ts
@@ -3,6 +3,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import { supabase } from "@/lib/supabase" // Supabase client for reads
 import { createContract, deleteContract } from "@/app/actions/contracts"
+import { useToast } from "@/hooks/use-toast"
 import { devLog } from "@/lib/dev-log"
 import type { Database } from "@/types/supabase"
 import { useEffect } from "react"
@@ -109,6 +110,7 @@ const deleteContractInSupabase = async (contractId: string): Promise<void> => {
 
 export const useDeleteContractMutation = () => {
   const queryClient = useQueryClient()
+  const { toast } = useToast()
   return useMutation<void, Error, string>({
     // contractId is a string
     mutationFn: deleteContractInSupabase,
@@ -121,7 +123,11 @@ export const useDeleteContractMutation = () => {
     },
     onError: (error) => {
       console.error("Error deleting contract:", error)
-      // Potentially show a toast notification to the user
+      toast({
+        title: "Error",
+        description: `Failed to delete contract: ${error.message}`,
+        variant: "destructive",
+      })
     },
   })
 }

--- a/hooks/use-delete-contract-mutation.test.tsx
+++ b/hooks/use-delete-contract-mutation.test.tsx
@@ -1,0 +1,48 @@
+import { render, fireEvent, waitFor, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useDeleteContractMutation } from "@/hooks/use-contracts";
+
+const toastMock = jest.fn();
+
+jest.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({
+    toast: toastMock,
+  }),
+}));
+
+const deleteContractMock = jest.fn();
+
+jest.mock("@/app/actions/contracts", () => ({
+  deleteContract: deleteContractMock,
+}));
+
+describe("useDeleteContractMutation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("shows toast when deletion fails", async () => {
+    deleteContractMock.mockRejectedValue(new Error("Delete failed"));
+
+    const queryClient = new QueryClient();
+
+    const TestComponent = () => {
+      const mutation = useDeleteContractMutation();
+      return <button onClick={() => mutation.mutate("123")}>Delete</button>;
+    };
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <TestComponent />
+      </QueryClientProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledWith(
+        expect.objectContaining({ variant: "destructive" }),
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- surface destructive toast in `useDeleteContractMutation`
- test deletion failure toast

## Testing
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853fdfb2bd48326a65ecf951b8463a0