### PR TITLE
Rename toastMock constant in test

### DIFF
--- a/components/contract-generator-form.test.tsx
+++ b/components/contract-generator-form.test.tsx
@@ -3,9 +3,9 @@ import userEvent from "@testing-library/user-event"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import ContractGeneratorForm from "./contract-generator-form"
 
-const mockToast = jest.fn()
+const toastMock = jest.fn()
 jest.mock("@/hooks/use-toast", () => ({
-  useToast: () => ({ toast: mockToast }),
+  useToast: () => ({ toast: toastMock }),
 }))
 
 import { useParties } from "@/hooks/use-parties"
@@ -122,6 +122,6 @@ describe("ContractGeneratorForm", () => {
       "/api/contracts",
       expect.objectContaining({ method: "POST" }),
     )
-    expect(mockToast).toHaveBeenCalled()
+    expect(toastMock).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary
- rename the mock toast variable in `contract-generator-form.test.tsx` to `toastMock`
- keep tests up to date

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854011200bc8326b5d86b05325231d4