### PR TITLE
Type-safe realtime payloads

### DIFF
--- a/components/dashboard/audit-logs.tsx
+++ b/components/dashboard/audit-logs.tsx
@@ -7,7 +7,7 @@ import { Input } from "@/components/ui/input"
 import { Search, Loader2, ArrowUpDown } from "lucide-react"
 import { supabase } from "@/lib/supabase"
 import { devLog } from "@/lib/dev-log"
-import type { AuditLogItem } from "@/lib/dashboard-types"
+import type { AuditLogItem, AuditLogRow } from "@/lib/dashboard-types"
 import { useToast } from "@/hooks/use-toast"
 import { format } from "date-fns"
 
@@ -32,7 +32,7 @@ export default function AuditLogs() {
 
       if (error) throw error
       setLogs(
-        data.map((log: any) => ({
+        data.map((log: AuditLogRow) => ({
           id: log.id,
           user: log.user_email || "System",
           action: log.action,
@@ -57,8 +57,11 @@ export default function AuditLogs() {
   useEffect(() => {
     const channel = supabase
       .channel("public:audit_logs:feed") // Unique channel name
-      .on("postgres_changes", { event: "INSERT", schema: "public", table: "audit_logs" }, (payload) => {
-        const newLog = payload.new as any
+      .on(
+        "postgres_changes",
+        { event: "INSERT", schema: "public", table: "audit_logs" },
+        (payload) => {
+          const newLog = payload.new as AuditLogRow
         devLog("New audit log received:", newLog)
         toast({
           title: "New Audit Log Entry",

--- a/components/dashboard/notification-system.tsx
+++ b/components/dashboard/notification-system.tsx
@@ -6,7 +6,7 @@ import { ScrollArea } from "@/components/ui/scroll-area"
 import { Button } from "@/components/ui/button"
 import { supabase } from "@/lib/supabase"
 import { devLog } from "@/lib/dev-log"
-import type { NotificationItem } from "@/lib/dashboard-types"
+import type { NotificationItem, NotificationRow } from "@/lib/dashboard-types"
 import { useToast } from "@/hooks/use-toast"
 import { formatDistanceToNow } from "date-fns"
 
@@ -43,7 +43,7 @@ export default function NotificationSystem() {
 
       if (error) throw error
       setNotifications(
-        data.map((n: any) => ({
+        data.map((n: NotificationRow) => ({
           id: n.id,
           type: n.type as NotificationItem["type"],
           message: n.message,
@@ -73,8 +73,11 @@ export default function NotificationSystem() {
     fetchNotifications()
     const channel = supabase
       .channel("public:notifications:feed") // Unique channel name
-      .on("postgres_changes", { event: "INSERT", schema: "public", table: "notifications" }, (payload) => {
-        const newNotif = payload.new as any
+      .on(
+        "postgres_changes",
+        { event: "INSERT", schema: "public", table: "notifications" },
+        (payload) => {
+          const newNotif = payload.new as NotificationRow
         devLog("New notification received:", newNotif)
         toast({ title: "New Notification", description: newNotif.message })
         setNotifications((prev) =>

--- a/components/promoter-profile-form.tsx
+++ b/components/promoter-profile-form.tsx
@@ -34,6 +34,17 @@ interface PromoterProfileFormProps {
   onFormSubmitSuccess?: (data: PromoterProfileFormData) => void // Callback for successful submission
 }
 
+type SubmissionData = Omit<
+  PromoterProfileFormData,
+  "id_card_image" | "passport_image"
+> & {
+  id_card_url: string | null
+  passport_url: string | null
+  contract_valid_until: string | null
+  id_card_expiry_date: string | null
+  passport_expiry_date: string | null
+}
+
 export default function PromoterProfileForm({ promoterToEdit, onFormSubmitSuccess }: PromoterProfileFormProps) {
   const { toast } = useToast()
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -101,18 +112,19 @@ export default function PromoterProfileForm({ promoterToEdit, onFormSubmitSucces
       // For example, upload `values.id_card_image` and `values.passport_image` if they are File objects.
       // Then, replace them with the returned URLs before saving to the database.
 
-      const submissionData = {
-        ...values,
+      const { id_card_image, passport_image, ...rest } = values
+      const submissionData: SubmissionData = {
+        ...rest,
         // This part is more about preparing data for a simulated API call.
         // The actual URL determination (upload new, use existing, or null)
         // would happen with your `uploadFile` function and Supabase logic.
         // For now, we assume `values.existing_id_card_url` is correctly nulled if removed.
         id_card_url:
-          values.id_card_image instanceof File
+          id_card_image instanceof File
             ? "new_file_placeholder_url_id_card.jpg" // Placeholder for new upload
             : values.existing_id_card_url,
         passport_url:
-          values.passport_image instanceof File
+          passport_image instanceof File
             ? "new_file_placeholder_url_passport.jpg" // Placeholder for new upload
             : values.existing_passport_url,
         contract_valid_until: values.contract_valid_until
@@ -125,9 +137,6 @@ export default function PromoterProfileForm({ promoterToEdit, onFormSubmitSucces
           ? format(new Date(values.passport_expiry_date), "yyyy-MM-dd")
           : null,
       }
-      // Remove file objects if you're not sending them directly
-      delete (submissionData as any).id_card_image
-      delete (submissionData as any).passport_image
 
       if (isEditMode) {
         // await api.updatePromoter(promoterToEdit.id, submissionData);

--- a/lib/dashboard-types.ts
+++ b/lib/dashboard-types.ts
@@ -55,6 +55,19 @@ export interface NotificationItem {
   related_entity_type?: string
 }
 
+// Row shape from the `notifications` table used in realtime payloads
+export interface NotificationRow {
+  id: string
+  type: NotificationItem["type"]
+  message: string
+  created_at: string
+  user_email?: string | null
+  related_contract_id?: string | null
+  related_entity_id?: string | null
+  related_entity_type?: string | null
+  is_read: boolean
+}
+
 export interface AuditLogItem {
   id: string
   user: string // Mapped from user_email or "System"
@@ -62,6 +75,16 @@ export interface AuditLogItem {
   ipAddress: string // Mapped from ip_address
   timestamp: string // ISO Date string from timestamp
   details?: string | object // Mapped from details
+}
+
+// Row shape from the `audit_logs` table used in realtime payloads
+export interface AuditLogRow {
+  id: string
+  user_email?: string | null
+  action: string
+  ip_address?: string | null
+  timestamp: string
+  details?: string | object | null
 }
 
 export interface ContractsByStatusDataPoint {


### PR DESCRIPTION
## Summary
- define `NotificationRow` and `AuditLogRow` interfaces
- use new interfaces in realtime callbacks
- refine `submissionData` in promoter profile form

## Testing
- `npx tsc --noEmit` *(fails: Cannot find modules and many TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68540113cdac8326a085d2cad746ead6