### PR TITLE
Fix placeholder image paths

### DIFF
--- a/app/promoters/profile-test/page.tsx
+++ b/app/promoters/profile-test/page.tsx
@@ -19,8 +19,9 @@ const samplePromoterToEdit: PromoterProfile = {
   work_location: "Tech Park, Building A",
   status: "active",
   contract_valid_until: "2025-12-31",
-  id_card_url: "/placeholder.svg?width=300&height=200",
-  passport_url: "/placeholder.svg?width=300&height=200",
+  // Use simple placeholder images without query parameters
+  id_card_url: "/placeholder.svg",
+  passport_url: "/placeholder.svg",
   id_card_expiry_date: "2026-06-15",
   passport_expiry_date: "2028-03-20",
   notes: "Excellent performance. Key contact for Tech Innovators project.",

--- a/components/dashboard/review-panel.tsx
+++ b/components/dashboard/review-panel.tsx
@@ -39,7 +39,8 @@ export default function ReviewPanel() {
         contractLink: `/contracts/${item.id}`, // Link to view the contract details
         // You might need to fetch submitter details (user_id) separately if not directly available
         submitter: item.user_id ? `User ${item.user_id.substring(0, 8)}...` : "System",
-        avatar: "/placeholder.svg?width=40&height=40",
+        // Use a static placeholder path without query params to avoid file system errors
+        avatar: "/placeholder.svg",
       }))
       setReviewItems(formattedItems)
     } catch (error: any) {

--- a/components/image-upload-field.tsx
+++ b/components/image-upload-field.tsx
@@ -90,7 +90,8 @@ export default function ImageUploadField({
         {displayPreviewUrl ? (
           <>
             <Image
-              src={displayPreviewUrl || "/placeholder.svg?width=190&height=190&query=preview"} // Adjusted placeholder size slightly for padding
+              // Use a simple placeholder path without query parameters
+              src={displayPreviewUrl || "/placeholder.svg"}
               alt={`Preview`}
               fill
               sizes="(max-width: 768px) 100vw, 480px" // Example sizes, adjust based on actual usage and container size
@@ -100,7 +101,8 @@ export default function ImageUploadField({
               onError={() => {
                 // This handles browser-side loading errors for the src
                 // The 400 error is likely from the Next.js optimization step before this
-                setPreview("/placeholder.svg?width=100&height=100")
+                // Fall back to a static placeholder without query params
+                setPreview("/placeholder.svg")
               }}
             />
             {!disabled && (


### PR DESCRIPTION
## Summary
- remove query parameters from placeholder image URLs

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685403effa008326991ac70aeda02e10