### PR TITLE
Improve channel error logging

### DIFF
--- a/hooks/use-contracts.ts
+++ b/hooks/use-contracts.ts
@@ -70,10 +70,11 @@ export const useContracts = () => {
           devLog("Subscribed to contracts channel!")
         }
         if (status === "CHANNEL_ERROR") {
-          console.error("Channel error:", err)
+          const message = err?.message ?? "Unknown channel error"
+          console.error(`Contracts channel error (${status}):`, message)
         }
         if (status === "TIMED_OUT") {
-          console.warn("Subscription timed out")
+          console.warn(`Subscription timed out (${status})`)
         }
       })
 

--- a/hooks/use-promoters.ts
+++ b/hooks/use-promoters.ts
@@ -77,7 +77,8 @@ export const usePromoters = () => {
       )
       .subscribe((status, err) => {
         if (status === "CHANNEL_ERROR") {
-          console.error("Promoters channel error:", err)
+          const message = err?.message ?? "Unknown channel error"
+          console.error(`Promoters channel error (${status}):`, message)
         }
       })
 


### PR DESCRIPTION
## Summary
- handle undefined errors in `use-promoters` subscription logging
- do the same for `use-contracts` with status info

## Testing
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68543715906883269529cd15f6cb4429