### PR TITLE
Add locale-specific login route

### DIFF
--- a/app/[locale]/login/error.tsx
+++ b/app/[locale]/login/error.tsx
@@ -1,0 +1,4 @@
+"use client"
+
+import ErrorPage from '@/app/error'
+export default ErrorPage

--- a/app/[locale]/login/loading.tsx
+++ b/app/[locale]/login/loading.tsx
@@ -1,0 +1,2 @@
+import Loading from '../../loading'
+export default Loading

--- a/app/[locale]/login/page.tsx
+++ b/app/[locale]/login/page.tsx
@@ -1,0 +1,9 @@
+import AuthForm from "@/components/auth-form"
+
+export default function LoginPage() {
+  return (
+    <div className="min-h-screen bg-background flex flex-col items-center justify-center p-4">
+      <AuthForm />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- copy existing login page, error and loading files into a new `[locale]/login` route
- adjust relative import for loading.tsx

## Testing
- `npm run lint` *(fails: `next` not found)*
- `pnpm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68543836bd3c83269d6525cafa52937c