### PR TITLE
Rename contract form component

### DIFF
--- a/app/[locale]/generate-contract/page.tsx
+++ b/app/[locale]/generate-contract/page.tsx
@@ -1,7 +1,7 @@
 // app/[locale]/generate-contract/page.tsx
 "use client"
 
-import ContractGeneratorForm from "@/components/contract-generator-form"
+import GenerateContractForm from "@/components/GenerateContractForm"
 import { motion } from "framer-motion"
 
 export default function GenerateContractPage() {
@@ -18,7 +18,7 @@ export default function GenerateContractPage() {
       </div>
       {/* Form container with padding, rounded corners, and shadow */}
       <div className="bg-card p-6 md:p-8 rounded-lg shadow-xl">
-        <ContractGeneratorForm />
+        <GenerateContractForm />
       </div>
     </motion.div>
   )

--- a/app/generate-contract/page.tsx
+++ b/app/generate-contract/page.tsx
@@ -1,9 +1,9 @@
-import ContractGeneratorForm from "@/components/contract-generator-form"
+import GenerateContractForm from "@/components/GenerateContractForm"
 
 export default function GenerateContractPage() {
   return (
     <div className="min-h-screen bg-background py-8 sm:py-12">
-      <ContractGeneratorForm />
+      <GenerateContractForm />
     </div>
   )
 }

--- a/components/GenerateContractForm.tsx
+++ b/components/GenerateContractForm.tsx
@@ -28,7 +28,7 @@ const sectionVariants = {
   visible: { opacity: 1, x: 0, transition: { duration: 0.5 } },
 }
 
-export default function ContractGeneratorForm() {
+export default function GenerateContractForm() {
   const queryClient = useQueryClient()
   const { toast } = useToast()
 

--- a/components/contract-generator-form.test.tsx
+++ b/components/contract-generator-form.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import ContractGeneratorForm from "./contract-generator-form"
+import GenerateContractForm from "./GenerateContractForm"
 
 const toastMock = jest.fn()
 jest.mock("@/hooks/use-toast", () => ({
@@ -44,12 +44,12 @@ function renderForm() {
   const queryClient = new QueryClient()
   return render(
     <QueryClientProvider client={queryClient}>
-      <ContractGeneratorForm />
+      <GenerateContractForm />
     </QueryClientProvider>,
   )
 }
 
-describe("ContractGeneratorForm", () => {
+describe("GenerateContractForm", () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockUseParties.mockImplementation((type: string) => {


### PR DESCRIPTION
## Summary
- rename contract generator component to `GenerateContractForm`
- update references in pages and tests

## Testing
- `pnpm test` *(fails: jest not found)*
- `pnpm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68543d78f9e4832698f4b56414f9d810