### PR TITLE
Add typed schema for new contract form

### DIFF
--- a/components/generate-contract-form.tsx
+++ b/components/generate-contract-form.tsx
@@ -1,0 +1,19 @@
+"use client"
+
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { z } from "zod"
+
+import { formSchema } from "@/lib/generate-contract-form-schema"
+
+export default function GenerateContractForm() {
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+  })
+
+  function onSubmit(values: z.infer<typeof formSchema>) {
+    console.log(values)
+  }
+
+  return <form onSubmit={form.handleSubmit(onSubmit)}></form>
+}

--- a/lib/generate-contract-form-schema.ts
+++ b/lib/generate-contract-form-schema.ts
@@ -1,0 +1,18 @@
+import { z } from "zod"
+
+export const formSchema = z
+  .object({
+    promoterId: z.string().uuid(),
+    firstPartyId: z.string().uuid(),
+    secondPartyId: z.string().uuid(),
+    startDate: z.date(),
+    endDate: z.date(),
+    refNumber: z.string(),
+    jobTitle: z.string().optional(),
+    workLocation: z.string().optional(),
+    email: z.string().email(),
+  })
+  .refine((d) => d.endDate > d.startDate, {
+    path: ["endDate"],
+    message: "End date must be after start date",
+  })


### PR DESCRIPTION
## Summary
- define `formSchema` for creating contracts
- implement minimal `GenerateContractForm` that uses typed `useForm`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `pnpm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68543d844a40832688c949b77d525e3b