### PR TITLE
Fix lint script and schema options

### DIFF
--- a/lib/schema-generator.ts
+++ b/lib/schema-generator.ts
@@ -8,6 +8,8 @@ export const contractGeneratorSchema = z
     contract_start_date: z.date({ required_error: "Contract start date is required." }),
     contract_end_date: z.date({ required_error: "Contract end date is required." }),
     email: z.string().email("Please enter a valid email address for notifications.").min(1, "Email is required."),
+    job_title: z.string().optional(),
+    work_location: z.string().optional(),
   })
   .refine((data) => data.contract_end_date >= data.contract_start_date, {
     message: "Contract end date must be on or after the start date.",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "next build",
     "dev": "node scripts/build-form.js && next dev",
-    "lint": "next lint",
+    "lint": "eslint .",
     "start": "next start",
     "test": "jest"
   },


### PR DESCRIPTION
## Summary
- use direct eslint command for linting
- allow optional job title and work location in contract schema

## Testing
- `pnpm install` *(fails: GET https://registry.npmjs.org/... Forbidden - 403)*
- `pnpm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854642764d483268c71a49302bcf732