### PR TITLE
Refactor forms to expose reset directly

### DIFF
--- a/components/GenerateContractForm.tsx
+++ b/components/GenerateContractForm.tsx
@@ -89,7 +89,7 @@ export default function GenerateContractForm() {
 
   const [promoterOptions, setPromoterOptions] = useState<{ value: string; label: string }[]>([])
 
-  const form = useForm<ContractGeneratorFormData>({
+  const { reset, ...form } = useForm<ContractGeneratorFormData>({
     resolver: zodResolver(contractGeneratorSchema),
     mode: "onTouched",
     defaultValues: {
@@ -152,7 +152,7 @@ export default function GenerateContractForm() {
         title: "Contract Created!",
         description: `PDF: ${data.contract.pdf_url || "Pending generation."}`,
       })
-      form.reset()
+      reset()
       queryClient.invalidateQueries({ queryKey: ["contracts"] })
     },
     onError: (error: any) => {

--- a/components/contract-generator-form.tsx
+++ b/components/contract-generator-form.tsx
@@ -82,7 +82,7 @@ export default function ContractGeneratorForm({
     { value: string; label: string }[]
   >([])
 
-  const form = useForm<ContractGeneratorFormData>({
+  const { reset, ...form } = useForm<ContractGeneratorFormData>({
     resolver: zodResolver(contractGeneratorSchema),
     mode: "onTouched",
     defaultValues: {
@@ -112,7 +112,7 @@ export default function ContractGeneratorForm({
   // When editing, pre-fill form values.
   useEffect(() => {
     if (contract) {
-      form.reset({
+      reset({
         first_party_id: contract.first_party_id ?? undefined,
         second_party_id: contract.second_party_id ?? undefined,
         promoter_id: contract.promoter_id ?? undefined,
@@ -214,7 +214,7 @@ export default function ContractGeneratorForm({
           : "PDF generation pending.",
       })
 
-      form.reset()
+      reset()
       queryClient.invalidateQueries({ queryKey: ["contracts"] })
       onFormSubmit?.()
 

--- a/components/generate-contract-form.tsx
+++ b/components/generate-contract-form.tsx
@@ -7,7 +7,7 @@ import { z } from "zod"
 import { formSchema } from "@/lib/generate-contract-form-schema"
 
 export default function GenerateContractForm() {
-  const form = useForm<z.infer<typeof formSchema>>({
+  const { reset, ...form } = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
   })
 

--- a/components/party-form.tsx
+++ b/components/party-form.tsx
@@ -21,7 +21,7 @@ export default function PartyForm({ partyToEdit, onFormSubmit }: PartyFormProps)
   const { toast } = useToast()
   const [isSubmitting, setIsSubmitting] = useState(false)
 
-  const form = useForm<PartyFormData>({
+  const { reset, ...form } = useForm<PartyFormData>({
     resolver: zodResolver(partyFormSchema),
     defaultValues: {
       name_en: "",
@@ -32,13 +32,13 @@ export default function PartyForm({ partyToEdit, onFormSubmit }: PartyFormProps)
 
   useEffect(() => {
     if (partyToEdit) {
-      form.reset({
+      reset({
         name_en: partyToEdit.name_en || "",
         name_ar: partyToEdit.name_ar || "",
         crn: partyToEdit.crn || "",
       })
     } else {
-      form.reset({
+      reset({
         name_en: "",
         name_ar: "",
         crn: "",

--- a/components/promoter-form.tsx
+++ b/components/promoter-form.tsx
@@ -68,7 +68,7 @@ export default function PromoterForm({ promoterToEdit, onFormSubmit }: PromoterF
   const isEditScreen = !!promoterToEdit
   const [isEditable, setIsEditable] = useState(!isEditScreen)
 
-  const form = useForm<PromoterProfileFormData>({
+  const { reset, ...form } = useForm<PromoterProfileFormData>({
     resolver: zodResolver(promoterProfileSchema),
     defaultValues: {
       name_en: "",
@@ -107,7 +107,7 @@ export default function PromoterForm({ promoterToEdit, onFormSubmit }: PromoterF
 
   useEffect(() => {
     if (promoterToEdit) {
-      form.reset({
+      reset({
         name_en: promoterToEdit.name_en || "",
         name_ar: promoterToEdit.name_ar || "",
         id_card_number: promoterToEdit.id_card_number || "",
@@ -133,7 +133,7 @@ export default function PromoterForm({ promoterToEdit, onFormSubmit }: PromoterF
         notes: promoterToEdit.notes || "",
       })
     } else {
-      form.reset({
+      reset({
         ...form.formState.defaultValues,
         status: "active",
         notify_days_before_id_expiry: 30,

--- a/components/promoter-profile-form.tsx
+++ b/components/promoter-profile-form.tsx
@@ -51,7 +51,7 @@ export default function PromoterProfileForm({ promoterToEdit, onFormSubmitSucces
   const isEditMode = !!promoterToEdit
   const [isEditable, setIsEditable] = useState(!isEditMode) // Editable by default in add mode
 
-  const form = useForm<PromoterProfileFormData>({
+  const { reset, ...form } = useForm<PromoterProfileFormData>({
     resolver: zodResolver(promoterProfileSchema),
     defaultValues: {
       name_en: "",
@@ -75,7 +75,7 @@ export default function PromoterProfileForm({ promoterToEdit, onFormSubmitSucces
 
   useEffect(() => {
     if (isEditMode && promoterToEdit) {
-      form.reset({
+      reset({
         name_en: promoterToEdit.name_en || "",
         name_ar: promoterToEdit.name_ar || "",
         id_card_number: promoterToEdit.id_card_number || "",
@@ -144,7 +144,7 @@ export default function PromoterProfileForm({ promoterToEdit, onFormSubmitSucces
       } else {
         // await api.createPromoter(submissionData);
         toast({ title: "Success!", description: "New promoter added successfully." })
-        form.reset() // Reset form after successful addition
+        reset() // Reset form after successful addition
       }
       onFormSubmitSuccess?.(values)
     } catch (error: any) {


### PR DESCRIPTION
## Summary
- extract `reset` from `useForm` calls
- use `reset()` instead of `form.reset()`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685464e4e3bc8326bcfb06c5a3ee9a4e