### PR TITLE
Refactor query provider env checks

### DIFF
--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -5,6 +5,9 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools"
 import { useState } from "react"
 
+const isDev = process.env.NODE_ENV === "development"
+const refetchOnFocus = process.env.NODE_ENV === "production"
+
 export function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(
     () =>
@@ -12,7 +15,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
         defaultOptions: {
           queries: {
             staleTime: 1000 * 60 * 5, // 5 minutes
-            refetchOnWindowFocus: process.env.NODE_ENV === "production", // Only in prod
+            refetchOnWindowFocus: refetchOnFocus, // Only in prod
           },
         },
       }),
@@ -21,7 +24,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <QueryClientProvider client={queryClient}>
       {children}
-      {process.env.NODE_ENV === "development" && <ReactQueryDevtools initialIsOpen={false} />}
+      {isDev && <ReactQueryDevtools initialIsOpen={false} />}
     </QueryClientProvider>
   )
 }


### PR DESCRIPTION
## Summary
- add constants `isDev` and `refetchOnFocus` in `app/providers.tsx`
- replace inline `process.env.NODE_ENV` checks with constants

## Testing
- `npm test` *(fails: jest not found)*
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685474ada5448326be33003096784561