### PR TITLE
Add explicit Supabase env validation

### DIFF
--- a/lib/__tests__/supabase-env.test.ts
+++ b/lib/__tests__/supabase-env.test.ts
@@ -1,0 +1,53 @@
+import { jest } from '@jest/globals'
+
+const ORIGINAL_ENV = process.env
+
+beforeEach(() => {
+  jest.resetModules()
+  process.env = { ...ORIGINAL_ENV }
+})
+
+afterAll(() => {
+  process.env = ORIGINAL_ENV
+})
+
+describe('Supabase environment variables', () => {
+  it('throws when client env vars are missing', async () => {
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL
+    delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+    await expect(import('../supabase')).rejects.toThrow(
+      /NEXT_PUBLIC_SUPABASE_URL.*NEXT_PUBLIC_SUPABASE_ANON_KEY/,
+    )
+  })
+
+  it('throws when server env vars are missing', async () => {
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL
+    delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+    await expect(import('../supabaseServer')).rejects.toThrow(
+      /NEXT_PUBLIC_SUPABASE_URL.*NEXT_PUBLIC_SUPABASE_ANON_KEY/,
+    )
+  })
+
+  it('throws when admin env vars are missing', async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.supabase.co'
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY
+    await expect(import('../supabase/admin')).rejects.toThrow(
+      /SUPABASE_SERVICE_ROLE_KEY/,
+    )
+  })
+
+  it('does not throw when all vars are set', async () => {
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.supabase.co'
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'anon'
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'service'
+
+    const client = await import('../supabase')
+    expect(client.supabase).toBeDefined()
+
+    const server = await import('../supabaseServer')
+    expect(server.createServerComponentClient).toBeDefined()
+
+    const admin = await import('../supabase/admin')
+    expect(admin.getSupabaseAdmin()).toBeDefined()
+  })
+})

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,16 +1,12 @@
 import { createClient } from "@supabase/supabase-js"
 import type { Database } from "@/types/supabase"
 
-const supabaseUrl =
-  process.env.NEXT_PUBLIC_SUPABASE_URL ||
-  "https://ekdjxzhujettocosgzql.supabase.co"
-const supabaseAnonKey =
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
-  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImVrZGp4emh1amV0dG9jb3NnenFsIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDkzMTkxMDYsImV4cCI6MjA2NDg5NTEwNn0.6VGbocKFVLNX_MCIOwFtdEssMk6wd_UQ5yNT1CfV6BA"
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 
-if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
-  console.warn(
-    "NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY is not set. Falling back to example credentials.",
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error(
+    "Environment variables NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY are required.",
   )
 }
 

--- a/lib/supabase/admin.ts
+++ b/lib/supabase/admin.ts
@@ -8,16 +8,12 @@ export function getSupabaseAdmin(): SupabaseClient<Database> {
     return supabaseAdminInstance
   }
 
-  const supabaseUrl =
-    process.env.NEXT_PUBLIC_SUPABASE_URL ||
-    "https://ekdjxzhujettocosgzql.supabase.co"
-  const supabaseServiceRoleKey =
-    process.env.SUPABASE_SERVICE_ROLE_KEY ||
-    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImVrZGp4emh1amV0dG9jb3NnenFsIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc0OTMxOTEwNiwiZXhwIjoyMDY0ODk1MTA2fQ.dAf5W8m9Q8FGlLY19Lo2x8JYSfq3RuFMAsHaPcH3F7A"
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
 
-  if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.SUPABASE_SERVICE_ROLE_KEY) {
-    console.warn(
-      "NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY is not set. Falling back to example credentials.",
+  if (!supabaseUrl || !supabaseServiceRoleKey) {
+    throw new Error(
+      "Environment variables NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are required.",
     )
   }
 

--- a/lib/supabaseServer.ts
+++ b/lib/supabaseServer.ts
@@ -4,16 +4,12 @@ import type { Database } from "@/types/supabase"
 
 export function createServerComponentClient() {
   const cookieStore = cookies()
-  const supabaseUrl =
-    process.env.NEXT_PUBLIC_SUPABASE_URL ||
-    "https://ekdjxzhujettocosgzql.supabase.co"
-  const supabaseAnonKey =
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ||
-    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImVrZGp4emh1amV0dG9jb3NnenFsIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDkzMTkxMDYsImV4cCI6MjA2NDg5NTEwNn0.6VGbocKFVLNX_MCIOwFtdEssMk6wd_UQ5yNT1CfV6BA"
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 
-  if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
-    console.warn(
-      "NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY is not set. Falling back to example credentials.",
+  if (!supabaseUrl || !supabaseAnonKey) {
+    throw new Error(
+      "Environment variables NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY are required.",
     )
   }
 


### PR DESCRIPTION
## Summary
- throw errors in Supabase client helpers when required env vars are missing
- add tests ensuring missing credentials throw errors

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685474aeeb748326b904aff2a5cf0d40