### PR TITLE
Pin ESLint to v8 for Next.js compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@types/node": "^22",
     "@types/react": "^18",
     "@types/react-dom": "^18",
-    "eslint": "latest",
+    "eslint": "^8.56.0",
     "jest": "^29",
     "postcss": "^8.5",
     "tailwindcss": "^3.4.17",
@@ -87,3 +87,4 @@
     "typescript": "^5"
   }
 }
+


### PR DESCRIPTION
## Summary
- pin `eslint` to `^8.56.0`

## Testing
- `pnpm install` *(fails: ERR_PNPM_FETCH_403)*

------
https://chatgpt.com/codex/tasks/task_e_685475b8e708832697a55d776d213746