### PR TITLE
Integrate manual error boundary

### DIFF
--- a/app/[locale]/contracts/[id]/layout.tsx
+++ b/app/[locale]/contracts/[id]/layout.tsx
@@ -1,5 +1,0 @@
-import type React from "react"
-
-export default function ContractIdLayout({ children }: { children: React.ReactNode }) {
-  return <>{children}</>
-}

--- a/components/ManualErrorBoundary.tsx
+++ b/components/ManualErrorBoundary.tsx
@@ -12,13 +12,13 @@ export class ManualErrorBoundary extends React.Component<
 > {
   constructor(props: { children: React.ReactNode }) {
     super(props)
-    // For AbuAli85 - This is a manual error boundary to work around the broken environment.
-    // Generated at: 2025-06-20 10:19:31 UTC
+    // For AbuAli85 - Final Strategy: Manual Error Boundary
+    // This avoids the broken file system detection in your environment.
+    // Generated at: 2025-06-20 10:23:48 UTC
     this.state = { hasError: false }
   }
 
   static getDerivedStateFromError(error: Error): State {
-    // Update state so the next render will show the fallback UI.
     return { hasError: true }
   }
 
@@ -28,16 +28,15 @@ export class ManualErrorBoundary extends React.Component<
 
   render() {
     if (this.state.hasError) {
-      // You can render any custom fallback UI
       return (
-        <div className="p-4">
-            <h2 className="font-semibold">An Error Occurred</h2>
-            <p>We ran into a problem loading this component.</p>
+        <div className="p-4 border border-red-500">
+            <h2 className="font-semibold text-red-700">An Error Occurred</h2>
+            <p>This part of the application has crashed.</p>
             <button
                 onClick={() => this.setState({ hasError: false })}
                 className="underline text-sm"
             >
-                Try again
+                Try to reload this component
             </button>
         </div>
       )


### PR DESCRIPTION
## Summary
- add manual error boundary component
- remove `[locale]/contracts/[id]/layout.tsx`
- ensure contract page is wrapped in the manual error boundary

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685536eda82c8326b33ffb6152f9b7f0