### PR TITLE
Clarify test steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ dependencies before running the tests:
 pnpm install
 \`\`\`
 
-After the dependencies are installed, execute the Jest test suite with:
+You must run `pnpm install` before `pnpm test` so all dependencies are available.
+After the install completes, execute the Jest test suite with:
 
 \`\`\`bash
 pnpm test

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "node scripts/build-form.js && next dev",
     "lint": "eslint .",
     "start": "next start",
+    "pretest": "pnpm install --frozen-lockfile || true",
     "test": "jest"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- clarify that `pnpm install` must run before `pnpm test`
- add a `pretest` script to automatically install deps

## Testing
- `pnpm test` *(fails: unable to install packages in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68555f376f108326be201259463260cf