### PR TITLE
Fix placeholder image paths

### DIFF
--- a/app/promoters/profile-test/page.tsx
+++ b/app/promoters/profile-test/page.tsx
@@ -6,7 +6,8 @@
 import PromoterProfileForm from "@/components/promoter-profile-form"
 import type { PromoterProfile } from "@/lib/types"
 import { devLog } from "@/lib/dev-log"
-import placeholderSvg from "@/public/placeholder.svg"
+// Direct path string avoids build-time file reads that can fail
+const placeholderSvg = "/placeholder.svg"
 
 // Sample data for editing (optional)
 const samplePromoterToEdit: PromoterProfile = {

--- a/components/dashboard/review-panel.tsx
+++ b/components/dashboard/review-panel.tsx
@@ -7,7 +7,10 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Badge } from "@/components/ui/badge"
 import { ThumbsUp, ThumbsDown, MessageSquare, Loader2 } from "lucide-react"
 import { supabase } from "@/lib/supabase"
-import placeholderAvatar from "@/public/placeholder.svg"
+// Use a static path rather than importing the file. Importing triggered
+// filesystem lookups on `/public/placeholder.svg` which fail in some
+// environments.
+const placeholderAvatar = "/placeholder.svg"
 import { devLog } from "@/lib/dev-log"
 import type { ReviewItem } from "@/lib/dashboard-types" // Ensure this type is defined
 import { useToast } from "@/hooks/use-toast"

--- a/components/image-upload-field.tsx
+++ b/components/image-upload-field.tsx
@@ -4,7 +4,11 @@
 import type React from "react"
 import { useState, useEffect, useRef } from "react"
 import Image from "next/image"
-import placeholderSrc from "@/public/placeholder.svg"
+
+// Use a direct path string so Next.js doesn't try to read from the filesystem
+// during the build phase. Importing the file caused errors like
+// `EISDIR: illegal operation on a directory` in some environments.
+const placeholderSrc = "/placeholder.svg"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 // Removed Label import from here, will be used from parent


### PR DESCRIPTION
## Summary
- avoid importing public images directly
- use static URL strings for placeholder images

## Testing
- `npm test` *(fails: ERR_PNPM_OUTDATED_LOCKFILE, jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855728cf8708326bb3d5da9ace7cf05