### PR TITLE
Fix Supabase env var assertions

### DIFF
--- a/lib/__tests__/supabase-env.test.ts
+++ b/lib/__tests__/supabase-env.test.ts
@@ -15,19 +15,25 @@ describe('Supabase environment variables', () => {
   it('throws when client env vars are missing', async () => {
     delete process.env.NEXT_PUBLIC_SUPABASE_URL
     delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
-    await expect(import('../supabase')).rejects.toThrow()
+    await expect(import('../supabase')).rejects.toThrow(
+      /NEXT_PUBLIC_SUPABASE_URL.*NEXT_PUBLIC_SUPABASE_ANON_KEY/,
+    )
   })
 
   it('throws when server env vars are missing', async () => {
     delete process.env.NEXT_PUBLIC_SUPABASE_URL
     delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
-    await expect(import('../supabaseServer')).rejects.toThrow()
+    await expect(import('../supabaseServer')).rejects.toThrow(
+      /NEXT_PUBLIC_SUPABASE_URL.*NEXT_PUBLIC_SUPABASE_ANON_KEY/,
+    )
   })
 
   it('throws when admin env vars are missing', async () => {
     process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.supabase.co'
     delete process.env.SUPABASE_SERVICE_ROLE_KEY
-    await expect(import('../supabase/admin')).rejects.toThrow()
+    await expect(import('../supabase/admin')).rejects.toThrow(
+      /NEXT_PUBLIC_SUPABASE_URL.*SUPABASE_SERVICE_ROLE_KEY/,
+    )
   })
 
   it('does not throw when all vars are set', async () => {


### PR DESCRIPTION
## Summary
- strengthen environment variable checks in Supabase tests

## Testing
- `pnpm test` *(fails: Cannot install with "frozen-lockfile" because pnpm-lock.yaml is outdated)*

------
https://chatgpt.com/codex/tasks/task_e_68557f7aca708326adfdedfc706e7b54