### PR TITLE
Fix tsconfig include path

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,6 @@
       "/app/*": ["./app/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "app/components/ui/sonner.tsx"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- remove redundant sonner component path from tsconfig include

## Testing
- `npx tsc --noEmit` *(fails: Cannot find name 'expect', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68557f7eb4e88326a4db302c596ca61b