### PR TITLE
Fix manual request link

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -53,7 +53,7 @@ const actions = [
   {
     title: "Request New Contract (Manual)",
     description: "Submit a request using a detailed form.",
-    href: "/request-contract",
+    href: "/generate-contract",
     icon: FileTextIcon,
     variant: "outline" as const,
   },


### PR DESCRIPTION
## Summary
- update manual request action to point to `/generate-contract`

## Testing
- `pnpm install` *(fails: Forbidden - 403)*
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856644c79a883268b7ed35a4b04605c