### PR TITLE
Remove unused path import from next config

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,3 @@
-import path from 'path'
-
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,


### PR DESCRIPTION
## Summary
- clean up `next.config.mjs` by removing the leftover `path` import

## Testing
- `pnpm lint` *(fails: ESLint couldn't find eslint.config.js)*
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856984b923883269eb8329560778a79