### PR TITLE
Fix Jest app alias

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -10,7 +10,7 @@ const config = {
   testEnvironment: 'jest-environment-jsdom',
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',
-    '^pp/(.*)$': '<rootDir>/app/$1'
+    '^app/(.*)$': '<rootDir>/app/$1'
   },
   preset: 'ts-jest', // if using TypeScript
 }


### PR DESCRIPTION
## Summary
- update Jest alias for app path

## Testing
- `npm test` *(fails: pnpm lockfile outdated, jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68569aaafef4832688ab872d24122c20