### PR TITLE
Add path import to next config

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,3 +1,5 @@
+import path from 'path'
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,


### PR DESCRIPTION
## Summary
- allow webpack aliases to use the path module in `next.config.mjs`

## Testing
- `npm test` *(fails: ERR_PNPM_OUTDATED_LOCKFILE)*

------
https://chatgpt.com/codex/tasks/task_e_68569cb6cfe4832693630e3d28e4c1d1