### PR TITLE
Remove duplicate app alias

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -20,7 +20,6 @@ const nextConfig = {
   },
   webpack: (config) => {
     // Allow absolute imports from the /app directory
-    config.resolve.alias['/app'] = path.resolve(__dirname, 'app')
     config.resolve.alias['app'] = path.resolve(__dirname, 'app')
     return config
   },


### PR DESCRIPTION
## Summary
- tidy webpack aliases in `next.config.mjs`
- confirm `globals.css` referenced relatively

## Testing
- `pnpm test` *(fails: jest not found)*
- `pnpm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68569cb9bd0c8326bb5f5e1ce83109f4