### PR TITLE
Fix CSS path for shadcn

### DIFF
--- a/components.json
+++ b/components.json
@@ -5,7 +5,7 @@
   "tsx": true,
   "tailwind": {
     "config": "tailwind.config.ts",
-  "css": "./app/globals.css",
+  "css": "public/app/globals.css",
     "baseColor": "neutral",
     "cssVariables": true,
     "prefix": ""


### PR DESCRIPTION
## Summary
- make Shadcn UI use `public/app/globals.css`

## Testing
- `pnpm install` *(fails: Forbidden - 403)*
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68569cd5edb48326b13eae64c847cb2f