### PR TITLE
Add missing path import

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,3 +1,5 @@
+import path from 'path'
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,


### PR DESCRIPTION
## Summary
- add `import path from 'path'` to `next.config.mjs`

## Testing
- `node --check next.config.mjs`
- `npm test` *(fails: ERR_PNPM_OUTDATED_LOCKFILE)*

------
https://chatgpt.com/codex/tasks/task_e_68569cd94e5883269d99a4015438b2ca