### PR TITLE
Add autoprefixer to PostCSS plugins

### DIFF
--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -2,6 +2,7 @@
 const config = {
   plugins: {
     tailwindcss: {},
+    autoprefixer: {},
   },
 };
 


### PR DESCRIPTION
## Summary
- include `autoprefixer` in PostCSS configuration

## Testing
- `pnpm build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68569eab3a30832685074c0c1b44df89