### PR TITLE
Add named export for Loading components

### DIFF
--- a/app/[locale]/generate-contract/loading.tsx
+++ b/app/[locale]/generate-contract/loading.tsx
@@ -1,2 +1,3 @@
-import Loading from '../../loading'
+import { Loading } from '../../loading'
+export { Loading }
 export default Loading

--- a/app/[locale]/loading.tsx
+++ b/app/[locale]/loading.tsx
@@ -1,2 +1,3 @@
-import Loading from '../loading'
+import { Loading } from '../loading'
+export { Loading }
 export default Loading

--- a/app/[locale]/login/loading.tsx
+++ b/app/[locale]/login/loading.tsx
@@ -1,2 +1,3 @@
-import Loading from '../../loading'
+import { Loading } from '../../loading'
+export { Loading }
 export default Loading

--- a/app/[locale]/manage-parties/loading.tsx
+++ b/app/[locale]/manage-parties/loading.tsx
@@ -1,2 +1,3 @@
-import Loading from '../../loading'
+import { Loading } from '../../loading'
+export { Loading }
 export default Loading

--- a/app/[locale]/manage-promoters/loading.tsx
+++ b/app/[locale]/manage-promoters/loading.tsx
@@ -1,2 +1,3 @@
-import Loading from '../../loading'
+import { Loading } from '../../loading'
+export { Loading }
 export default Loading

--- a/app/contracts/[id]/loading.tsx
+++ b/app/contracts/[id]/loading.tsx
@@ -1,2 +1,3 @@
-import Loading from '../../loading'
+import { Loading } from '../../loading'
+export { Loading }
 export default Loading

--- a/app/contracts/loading.tsx
+++ b/app/contracts/loading.tsx
@@ -1,2 +1,3 @@
-import Loading from '../loading'
+import { Loading } from '../loading'
+export { Loading }
 export default Loading

--- a/app/dashboard/analytics/loading.tsx
+++ b/app/dashboard/analytics/loading.tsx
@@ -1,2 +1,3 @@
-import Loading from '../../loading'
+import { Loading } from '../../loading'
+export { Loading }
 export default Loading

--- a/app/dashboard/audit/loading.tsx
+++ b/app/dashboard/audit/loading.tsx
@@ -1,2 +1,3 @@
-import Loading from '../../loading'
+import { Loading } from '../../loading'
+export { Loading }
 export default Loading

--- a/app/dashboard/contracts/loading.tsx
+++ b/app/dashboard/contracts/loading.tsx
@@ -1,2 +1,3 @@
-import Loading from '../../loading'
+import { Loading } from '../../loading'
+export { Loading }
 export default Loading

--- a/app/dashboard/loading.tsx
+++ b/app/dashboard/loading.tsx
@@ -1,2 +1,3 @@
-import Loading from '../loading'
+import { Loading } from '../loading'
+export { Loading }
 export default Loading

--- a/app/dashboard/notifications/loading.tsx
+++ b/app/dashboard/notifications/loading.tsx
@@ -1,2 +1,3 @@
-import Loading from '../../loading'
+import { Loading } from '../../loading'
+export { Loading }
 export default Loading

--- a/app/dashboard/settings/loading.tsx
+++ b/app/dashboard/settings/loading.tsx
@@ -1,2 +1,3 @@
-import Loading from '../../loading'
+import { Loading } from '../../loading'
+export { Loading }
 export default Loading

--- a/app/dashboard/users/loading.tsx
+++ b/app/dashboard/users/loading.tsx
@@ -1,2 +1,3 @@
-import Loading from '../../loading'
+import { Loading } from '../../loading'
+export { Loading }
 export default Loading

--- a/app/edit-contract/[id]/loading.tsx
+++ b/app/edit-contract/[id]/loading.tsx
@@ -1,2 +1,3 @@
-import Loading from '../../../loading'
+import { Loading } from '../../../loading'
+export { Loading }
 export default Loading

--- a/app/generate-contract/loading.tsx
+++ b/app/generate-contract/loading.tsx
@@ -1,2 +1,3 @@
-import Loading from '../loading'
+import { Loading } from '../loading'
+export { Loading }
 export default Loading

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,7 +1,8 @@
 // For AbuAli85 - A global loading indicator to fix the missing module error.
 // Generated at: 2025-06-20 13:14:49 UTC
+import React from "react"
 
-export default function Loading() {
+export function Loading() {
   // This is a simple spinner. You can customize it with any loading UI you want.
   return (
     <div className="flex justify-center items-center h-screen">
@@ -9,3 +10,5 @@ export default function Loading() {
     </div>
   );
 }
+
+export default Loading

--- a/app/login/loading.tsx
+++ b/app/login/loading.tsx
@@ -1,2 +1,3 @@
-import Loading from '../loading'
+import { Loading } from '../loading'
+export { Loading }
 export default Loading

--- a/app/manage-parties/loading.tsx
+++ b/app/manage-parties/loading.tsx
@@ -1,2 +1,3 @@
-import Loading from '../loading'
+import { Loading } from '../loading'
+export { Loading }
 export default Loading

--- a/app/manage-promoters/[id]/edit/loading.tsx
+++ b/app/manage-promoters/[id]/edit/loading.tsx
@@ -1,2 +1,3 @@
-import Loading from '../../../loading'
+import { Loading } from '../../../loading'
+export { Loading }
 export default Loading

--- a/app/manage-promoters/[id]/loading.tsx
+++ b/app/manage-promoters/[id]/loading.tsx
@@ -1,2 +1,3 @@
-import Loading from '../../loading'
+import { Loading } from '../../loading'
+export { Loading }
 export default Loading

--- a/app/manage-promoters/loading.tsx
+++ b/app/manage-promoters/loading.tsx
@@ -1,2 +1,3 @@
-import Loading from '../loading'
+import { Loading } from '../loading'
+export { Loading }
 export default Loading

--- a/app/promoters/profile-test/loading.tsx
+++ b/app/promoters/profile-test/loading.tsx
@@ -1,2 +1,3 @@
-import Loading from '../../loading'
+import { Loading } from '../../loading'
+export { Loading }
 export default Loading


### PR DESCRIPTION
## Summary
- export root Loading as a named component and default
- re-export named Loading in nested loading boundaries

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856b0d3e1748326bd0e768f9318f0c5