### PR TITLE
Fix Next.js loading export

### DIFF
--- a/app/[locale]/generate-contract/loading.tsx
+++ b/app/[locale]/generate-contract/loading.tsx
@@ -1,3 +1,13 @@
-import { Loading } from '../../loading'
-export { Loading }
+import React from "react"
+import { Loader2 } from "lucide-react"
+
+export function Loading() {
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <Loader2 className="h-10 w-10 animate-spin text-primary" />
+    </div>
+  )
+}
+
 export default Loading
+

--- a/app/[locale]/loading.tsx
+++ b/app/[locale]/loading.tsx
@@ -1,3 +1,13 @@
-import { Loading } from '../loading'
-export { Loading }
+import React from "react"
+import { Loader2 } from "lucide-react"
+
+export function Loading() {
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <Loader2 className="h-10 w-10 animate-spin text-primary" />
+    </div>
+  )
+}
+
 export default Loading
+

--- a/app/[locale]/login/loading.tsx
+++ b/app/[locale]/login/loading.tsx
@@ -1,3 +1,13 @@
-import { Loading } from '../../loading'
-export { Loading }
+import React from "react"
+import { Loader2 } from "lucide-react"
+
+export function Loading() {
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <Loader2 className="h-10 w-10 animate-spin text-primary" />
+    </div>
+  )
+}
+
 export default Loading
+

--- a/app/[locale]/manage-parties/loading.tsx
+++ b/app/[locale]/manage-parties/loading.tsx
@@ -1,3 +1,13 @@
-import { Loading } from '../../loading'
-export { Loading }
+import React from "react"
+import { Loader2 } from "lucide-react"
+
+export function Loading() {
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <Loader2 className="h-10 w-10 animate-spin text-primary" />
+    </div>
+  )
+}
+
 export default Loading
+

--- a/app/[locale]/manage-promoters/loading.tsx
+++ b/app/[locale]/manage-promoters/loading.tsx
@@ -1,3 +1,13 @@
-import { Loading } from '../../loading'
-export { Loading }
+import React from "react"
+import { Loader2 } from "lucide-react"
+
+export function Loading() {
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <Loader2 className="h-10 w-10 animate-spin text-primary" />
+    </div>
+  )
+}
+
 export default Loading
+

--- a/app/contracts/[id]/loading.tsx
+++ b/app/contracts/[id]/loading.tsx
@@ -1,3 +1,13 @@
-import { Loading } from '../../loading'
-export { Loading }
+import React from "react"
+import { Loader2 } from "lucide-react"
+
+export function Loading() {
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <Loader2 className="h-10 w-10 animate-spin text-primary" />
+    </div>
+  )
+}
+
 export default Loading
+

--- a/app/contracts/loading.tsx
+++ b/app/contracts/loading.tsx
@@ -1,3 +1,13 @@
-import { Loading } from '../loading'
-export { Loading }
+import React from "react"
+import { Loader2 } from "lucide-react"
+
+export function Loading() {
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <Loader2 className="h-10 w-10 animate-spin text-primary" />
+    </div>
+  )
+}
+
 export default Loading
+

--- a/app/dashboard/analytics/loading.tsx
+++ b/app/dashboard/analytics/loading.tsx
@@ -1,3 +1,13 @@
-import { Loading } from '../../loading'
-export { Loading }
+import React from "react"
+import { Loader2 } from "lucide-react"
+
+export function Loading() {
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <Loader2 className="h-10 w-10 animate-spin text-primary" />
+    </div>
+  )
+}
+
 export default Loading
+

--- a/app/dashboard/audit/loading.tsx
+++ b/app/dashboard/audit/loading.tsx
@@ -1,3 +1,13 @@
-import { Loading } from '../../loading'
-export { Loading }
+import React from "react"
+import { Loader2 } from "lucide-react"
+
+export function Loading() {
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <Loader2 className="h-10 w-10 animate-spin text-primary" />
+    </div>
+  )
+}
+
 export default Loading
+

--- a/app/dashboard/contracts/loading.tsx
+++ b/app/dashboard/contracts/loading.tsx
@@ -1,3 +1,13 @@
-import { Loading } from '../../loading'
-export { Loading }
+import React from "react"
+import { Loader2 } from "lucide-react"
+
+export function Loading() {
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <Loader2 className="h-10 w-10 animate-spin text-primary" />
+    </div>
+  )
+}
+
 export default Loading
+

--- a/app/dashboard/loading.tsx
+++ b/app/dashboard/loading.tsx
@@ -1,3 +1,13 @@
-import { Loading } from '../loading'
-export { Loading }
+import React from "react"
+import { Loader2 } from "lucide-react"
+
+export function Loading() {
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <Loader2 className="h-10 w-10 animate-spin text-primary" />
+    </div>
+  )
+}
+
 export default Loading
+

--- a/app/dashboard/notifications/loading.tsx
+++ b/app/dashboard/notifications/loading.tsx
@@ -1,3 +1,13 @@
-import { Loading } from '../../loading'
-export { Loading }
+import React from "react"
+import { Loader2 } from "lucide-react"
+
+export function Loading() {
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <Loader2 className="h-10 w-10 animate-spin text-primary" />
+    </div>
+  )
+}
+
 export default Loading
+

--- a/app/dashboard/settings/loading.tsx
+++ b/app/dashboard/settings/loading.tsx
@@ -1,3 +1,13 @@
-import { Loading } from '../../loading'
-export { Loading }
+import React from "react"
+import { Loader2 } from "lucide-react"
+
+export function Loading() {
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <Loader2 className="h-10 w-10 animate-spin text-primary" />
+    </div>
+  )
+}
+
 export default Loading
+

--- a/app/dashboard/users/loading.tsx
+++ b/app/dashboard/users/loading.tsx
@@ -1,3 +1,13 @@
-import { Loading } from '../../loading'
-export { Loading }
+import React from "react"
+import { Loader2 } from "lucide-react"
+
+export function Loading() {
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <Loader2 className="h-10 w-10 animate-spin text-primary" />
+    </div>
+  )
+}
+
 export default Loading
+

--- a/app/edit-contract/[id]/loading.tsx
+++ b/app/edit-contract/[id]/loading.tsx
@@ -1,3 +1,13 @@
-import { Loading } from '../../../loading'
-export { Loading }
+import React from "react"
+import { Loader2 } from "lucide-react"
+
+export function Loading() {
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <Loader2 className="h-10 w-10 animate-spin text-primary" />
+    </div>
+  )
+}
+
 export default Loading
+

--- a/app/generate-contract/loading.tsx
+++ b/app/generate-contract/loading.tsx
@@ -1,3 +1,13 @@
-import { Loading } from '../loading'
-export { Loading }
+import React from "react"
+import { Loader2 } from "lucide-react"
+
+export function Loading() {
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <Loader2 className="h-10 w-10 animate-spin text-primary" />
+    </div>
+  )
+}
+
 export default Loading
+

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,14 +1,12 @@
-// For AbuAli85 - A global loading indicator to fix the missing module error.
-// Generated at: 2025-06-20 13:14:49 UTC
 import React from "react"
+import { Loader2 } from "lucide-react"
 
 export function Loading() {
-  // This is a simple spinner. You can customize it with any loading UI you want.
   return (
-    <div className="flex justify-center items-center h-screen">
-      <div className="animate-spin rounded-full h-32 w-32 border-t-2 border-b-2 border-gray-900"></div>
+    <div className="flex h-full w-full items-center justify-center">
+      <Loader2 className="h-10 w-10 animate-spin text-primary" />
     </div>
-  );
+  )
 }
 
 export default Loading

--- a/app/login/loading.tsx
+++ b/app/login/loading.tsx
@@ -1,3 +1,13 @@
-import { Loading } from '../loading'
-export { Loading }
+import React from "react"
+import { Loader2 } from "lucide-react"
+
+export function Loading() {
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <Loader2 className="h-10 w-10 animate-spin text-primary" />
+    </div>
+  )
+}
+
 export default Loading
+

--- a/app/manage-parties/loading.tsx
+++ b/app/manage-parties/loading.tsx
@@ -1,3 +1,13 @@
-import { Loading } from '../loading'
-export { Loading }
+import React from "react"
+import { Loader2 } from "lucide-react"
+
+export function Loading() {
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <Loader2 className="h-10 w-10 animate-spin text-primary" />
+    </div>
+  )
+}
+
 export default Loading
+

--- a/app/manage-promoters/[id]/edit/loading.tsx
+++ b/app/manage-promoters/[id]/edit/loading.tsx
@@ -1,3 +1,13 @@
-import { Loading } from '../../../loading'
-export { Loading }
+import React from "react"
+import { Loader2 } from "lucide-react"
+
+export function Loading() {
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <Loader2 className="h-10 w-10 animate-spin text-primary" />
+    </div>
+  )
+}
+
 export default Loading
+

--- a/app/manage-promoters/[id]/loading.tsx
+++ b/app/manage-promoters/[id]/loading.tsx
@@ -1,3 +1,13 @@
-import { Loading } from '../../loading'
-export { Loading }
+import React from "react"
+import { Loader2 } from "lucide-react"
+
+export function Loading() {
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <Loader2 className="h-10 w-10 animate-spin text-primary" />
+    </div>
+  )
+}
+
 export default Loading
+

--- a/app/manage-promoters/loading.tsx
+++ b/app/manage-promoters/loading.tsx
@@ -1,3 +1,13 @@
-import { Loading } from '../loading'
-export { Loading }
+import React from "react"
+import { Loader2 } from "lucide-react"
+
+export function Loading() {
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <Loader2 className="h-10 w-10 animate-spin text-primary" />
+    </div>
+  )
+}
+
 export default Loading
+

--- a/app/promoters/profile-test/loading.tsx
+++ b/app/promoters/profile-test/loading.tsx
@@ -1,3 +1,13 @@
-import { Loading } from '../../loading'
-export { Loading }
+import React from "react"
+import { Loader2 } from "lucide-react"
+
+export function Loading() {
+  return (
+    <div className="flex h-full w-full items-center justify-center">
+      <Loader2 className="h-10 w-10 animate-spin text-primary" />
+    </div>
+  )
+}
+
 export default Loading
+


### PR DESCRIPTION
## Summary
- export a named `Loading` component from all route `loading.tsx` files

## Testing
- `npx prettier -w app/loading.tsx` *(fails: Cannot find package 'prettier-plugin-tailwindcss')*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856b1a34b8c8326a79b479bb4c65069