### PR TITLE
Fix globals.css usage and loading components

### DIFF
--- a/app/edit-contract/[id]/loading.tsx
+++ b/app/edit-contract/[id]/loading.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export function Loading() {
+export default function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />
@@ -9,5 +9,4 @@ export function Loading() {
   )
 }
 
-export default Loading
 

--- a/app/generate-contract/loading.tsx
+++ b/app/generate-contract/loading.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export function Loading() {
+export default function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />
@@ -9,5 +9,4 @@ export function Loading() {
   )
 }
 
-export default Loading
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,19 +1,17 @@
 import "./globals.css"
 import type { ReactNode } from "react"
 import type { Metadata } from "next"
-import ClientLayout from "./client-layout"
 
 export const metadata: Metadata = {
-  // Metadata should be in a server component or page.tsx
   title: "Bilingual Contract Generator",
   description: "Generate and manage bilingual contracts efficiently.",
-  generator: 'v0.dev'
+  generator: "v0.dev",
 }
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <ClientLayout>
-      {children}
-    </ClientLayout>
+    <html lang="en">
+      <body>{children}</body>
+    </html>
   )
 }


### PR DESCRIPTION
## Summary
- move global layout logic directly into `app/layout.tsx`
- ensure loading screens export a default component

## Testing
- `npm test` *(fails: jest not found, npm registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6856b3c38d8083268222b978ba70f033