### PR TITLE
Fix RootLayout to use ClientLayout with locale params

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import "./globals.css"
 import type { ReactNode } from "react"
 import type { Metadata } from "next"
+import ClientLayout from "./client-layout"
 
 export const metadata: Metadata = {
   title: "Bilingual Contract Generator",
@@ -8,10 +9,12 @@ export const metadata: Metadata = {
   generator: "v0.dev",
 }
 
-export default function RootLayout({ children }: { children: ReactNode }) {
-  return (
-    <html lang="en">
-      <body>{children}</body>
-    </html>
-  )
+export default function RootLayout({
+  children,
+  params,
+}: {
+  children: ReactNode
+  params: { locale: string }
+}) {
+  return <ClientLayout params={params}>{children}</ClientLayout>
 }


### PR DESCRIPTION
## Summary
- pass `params` from RootLayout down to ClientLayout

## Testing
- `pnpm lint` *(fails: cannot find package `@eslint/eslintrc`)*
- `pnpm test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6856b6ce3d1083268d5ddcc1812a7efd