### PR TITLE
Add loading fallback for contracts page

### DIFF
--- a/app/[locale]/contracts/loading.tsx
+++ b/app/[locale]/contracts/loading.tsx
@@ -1,0 +1,16 @@
+"use client"
+
+import { Loader2 } from "lucide-react"
+
+export function Loading() {
+  return (
+    <div className="flex h-full min-h-[200px] items-center justify-center space-x-2">
+      <Loader2 className="h-6 w-6 animate-spin text-primary" />
+      <span className="text-lg font-medium text-muted-foreground">
+        Loading contracts…
+      </span>
+    </div>
+  )
+}
+
+export default Loading


### PR DESCRIPTION
## Summary
- add Suspense fallback for `[locale]/contracts` route

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856b8ab5bac8326a8002be07b5f211d