### PR TITLE
Add motion variant types

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -6,9 +6,9 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
 import { FileTextIcon, FilePlus2Icon, History, UsersIcon, BuildingIcon, ExternalLinkIcon } from "lucide-react"
 import AuthStatus from "@/components/auth-status" // Assuming this component exists
-import { motion } from "framer-motion"
+import { motion, type Variants, type Easing } from "framer-motion"
 
-const cardVariants = {
+const cardVariants: Variants = {
   hidden: { opacity: 0, y: 20 },
   visible: (i: number) => ({
     opacity: 1,
@@ -16,7 +16,7 @@ const cardVariants = {
     transition: {
       delay: i * 0.1,
       duration: 0.5,
-      ease: "easeOut",
+      ease: [0.42, 0, 0.58, 1] as Easing,
     },
   }),
 }

--- a/components/contract-generator-form.tsx
+++ b/components/contract-generator-form.tsx
@@ -5,7 +5,7 @@ import { useForm, useWatch } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { format, parseISO } from "date-fns"
-import { motion } from "framer-motion"
+import { motion, type Variants, type Easing } from "framer-motion"
 import {
   Form,
   FormControl,
@@ -46,7 +46,7 @@ interface ContractGeneratorFormProps {
   onFormSubmit?: () => void
 }
 
-const sectionVariants = {
+const sectionVariants: Variants = {
   hidden: { opacity: 0, x: -20 },
   visible: { opacity: 1, x: 0, transition: { duration: 0.5 } },
 }


### PR DESCRIPTION
## Summary
- add Variants and Easing types from framer-motion
- type variant objects and use easing array instead of string

## Testing
- `pnpm test` *(fails: jest not found / registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6856b97481248326867ba54f8fc652d5