### PR TITLE
Add not-found page

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,14 @@
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+
+export default function NotFound() {
+  return (
+    <div className="min-h-[60vh] flex flex-col items-center justify-center space-y-4 text-center">
+      <h2 className="text-3xl font-bold">Page Not Found</h2>
+      <p className="text-muted-foreground">Sorry, the page you are looking for does not exist.</p>
+      <Button asChild>
+        <Link href="/">Go to Home</Link>
+      </Button>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add a global 404 page with a link back home

## Testing
- `pnpm test` *(fails: `ERR_PNPM_FETCH_403`)*

------
https://chatgpt.com/codex/tasks/task_e_6856b982b2f083269aa857ccbb23de09