### PR TITLE
Refactor loading components for consistent export

### DIFF
--- a/app/[locale]/contracts/loading.tsx
+++ b/app/[locale]/contracts/loading.tsx
@@ -2,7 +2,7 @@
 
 import { Loader2 } from "lucide-react"
 
-export function Loading() {
+export default function Loading() {
   return (
     <div className="flex h-full min-h-[200px] items-center justify-center space-x-2">
       <Loader2 className="h-6 w-6 animate-spin text-primary" />
@@ -13,4 +13,3 @@ export function Loading() {
   )
 }
 
-export default Loading

--- a/app/[locale]/generate-contract/loading.tsx
+++ b/app/[locale]/generate-contract/loading.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export function Loading() {
+export default function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />
@@ -9,5 +9,4 @@ export function Loading() {
   )
 }
 
-export default Loading
 

--- a/app/[locale]/loading.tsx
+++ b/app/[locale]/loading.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export function Loading() {
+export default function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />
@@ -9,5 +9,4 @@ export function Loading() {
   )
 }
 
-export default Loading
 

--- a/app/[locale]/login/loading.tsx
+++ b/app/[locale]/login/loading.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export function Loading() {
+export default function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />
@@ -9,5 +9,4 @@ export function Loading() {
   )
 }
 
-export default Loading
 

--- a/app/[locale]/manage-parties/loading.tsx
+++ b/app/[locale]/manage-parties/loading.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export function Loading() {
+export default function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />
@@ -9,5 +9,4 @@ export function Loading() {
   )
 }
 
-export default Loading
 

--- a/app/[locale]/manage-promoters/loading.tsx
+++ b/app/[locale]/manage-promoters/loading.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export function Loading() {
+export default function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />
@@ -9,5 +9,4 @@ export function Loading() {
   )
 }
 
-export default Loading
 

--- a/app/contracts/[id]/loading.tsx
+++ b/app/contracts/[id]/loading.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export function Loading() {
+export default function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />
@@ -9,5 +9,4 @@ export function Loading() {
   )
 }
 
-export default Loading
 

--- a/app/contracts/loading.tsx
+++ b/app/contracts/loading.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export function Loading() {
+export default function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />
@@ -9,5 +9,4 @@ export function Loading() {
   )
 }
 
-export default Loading
 

--- a/app/dashboard/analytics/loading.tsx
+++ b/app/dashboard/analytics/loading.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export function Loading() {
+export default function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />
@@ -9,5 +9,4 @@ export function Loading() {
   )
 }
 
-export default Loading
 

--- a/app/dashboard/audit/loading.tsx
+++ b/app/dashboard/audit/loading.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export function Loading() {
+export default function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />
@@ -9,5 +9,4 @@ export function Loading() {
   )
 }
 
-export default Loading
 

--- a/app/dashboard/contracts/loading.tsx
+++ b/app/dashboard/contracts/loading.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export function Loading() {
+export default function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />
@@ -9,5 +9,4 @@ export function Loading() {
   )
 }
 
-export default Loading
 

--- a/app/dashboard/loading.tsx
+++ b/app/dashboard/loading.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export function Loading() {
+export default function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />
@@ -9,5 +9,4 @@ export function Loading() {
   )
 }
 
-export default Loading
 

--- a/app/dashboard/notifications/loading.tsx
+++ b/app/dashboard/notifications/loading.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export function Loading() {
+export default function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />
@@ -9,5 +9,4 @@ export function Loading() {
   )
 }
 
-export default Loading
 

--- a/app/dashboard/settings/loading.tsx
+++ b/app/dashboard/settings/loading.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export function Loading() {
+export default function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />
@@ -9,5 +9,4 @@ export function Loading() {
   )
 }
 
-export default Loading
 

--- a/app/dashboard/users/loading.tsx
+++ b/app/dashboard/users/loading.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export function Loading() {
+export default function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />
@@ -9,5 +9,4 @@ export function Loading() {
   )
 }
 
-export default Loading
 

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export function Loading() {
+export default function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />
@@ -9,4 +9,3 @@ export function Loading() {
   )
 }
 
-export default Loading

--- a/app/login/loading.tsx
+++ b/app/login/loading.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export function Loading() {
+export default function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />
@@ -9,5 +9,4 @@ export function Loading() {
   )
 }
 
-export default Loading
 

--- a/app/manage-parties/loading.tsx
+++ b/app/manage-parties/loading.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export function Loading() {
+export default function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />
@@ -9,5 +9,4 @@ export function Loading() {
   )
 }
 
-export default Loading
 

--- a/app/manage-promoters/[id]/edit/loading.tsx
+++ b/app/manage-promoters/[id]/edit/loading.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export function Loading() {
+export default function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />
@@ -9,5 +9,4 @@ export function Loading() {
   )
 }
 
-export default Loading
 

--- a/app/manage-promoters/[id]/loading.tsx
+++ b/app/manage-promoters/[id]/loading.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export function Loading() {
+export default function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />
@@ -9,5 +9,4 @@ export function Loading() {
   )
 }
 
-export default Loading
 

--- a/app/manage-promoters/loading.tsx
+++ b/app/manage-promoters/loading.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export function Loading() {
+export default function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />
@@ -9,5 +9,4 @@ export function Loading() {
   )
 }
 
-export default Loading
 

--- a/app/promoters/profile-test/loading.tsx
+++ b/app/promoters/profile-test/loading.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export function Loading() {
+export default function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />
@@ -9,5 +9,4 @@ export function Loading() {
   )
 }
 
-export default Loading
 


### PR DESCRIPTION
## Summary
- unify loading components to use `export default function Loading()`

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/eslintrc')*
- `pnpm test` *(fails: GET https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.3.1.tgz: Forbidden - 403)*

------
https://chatgpt.com/codex/tasks/task_e_6856b98d8744832687993324c5a78e2d