### PR TITLE
Fix loading boundaries

### DIFF
--- a/app/[locale]/contracts/loading.tsx
+++ b/app/[locale]/contracts/loading.tsx
@@ -2,7 +2,7 @@
 
 import { Loader2 } from "lucide-react"
 
-export default function Loading() {
+export function Loading() {
   return (
     <div className="flex h-full min-h-[200px] items-center justify-center space-x-2">
       <Loader2 className="h-6 w-6 animate-spin text-primary" />

--- a/app/[locale]/generate-contract/loading.tsx
+++ b/app/[locale]/generate-contract/loading.tsx
@@ -1,7 +1,9 @@
+"use client"
+
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export default function Loading() {
+export function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />

--- a/app/[locale]/loading.tsx
+++ b/app/[locale]/loading.tsx
@@ -1,7 +1,9 @@
+"use client"
+
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export default function Loading() {
+export function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />

--- a/app/[locale]/login/loading.tsx
+++ b/app/[locale]/login/loading.tsx
@@ -1,7 +1,9 @@
+"use client"
+
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export default function Loading() {
+export function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />

--- a/app/[locale]/manage-parties/loading.tsx
+++ b/app/[locale]/manage-parties/loading.tsx
@@ -1,7 +1,9 @@
+"use client"
+
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export default function Loading() {
+export function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />

--- a/app/[locale]/manage-promoters/loading.tsx
+++ b/app/[locale]/manage-promoters/loading.tsx
@@ -1,7 +1,9 @@
+"use client"
+
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export default function Loading() {
+export function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />

--- a/app/contracts/[id]/loading.tsx
+++ b/app/contracts/[id]/loading.tsx
@@ -1,7 +1,9 @@
+"use client"
+
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export default function Loading() {
+export function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />

--- a/app/contracts/loading.tsx
+++ b/app/contracts/loading.tsx
@@ -1,7 +1,9 @@
+"use client"
+
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export default function Loading() {
+export function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />

--- a/app/dashboard/analytics/loading.tsx
+++ b/app/dashboard/analytics/loading.tsx
@@ -1,7 +1,9 @@
+"use client"
+
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export default function Loading() {
+export function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />

--- a/app/dashboard/audit/loading.tsx
+++ b/app/dashboard/audit/loading.tsx
@@ -1,7 +1,9 @@
+"use client"
+
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export default function Loading() {
+export function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />

--- a/app/dashboard/contracts/loading.tsx
+++ b/app/dashboard/contracts/loading.tsx
@@ -1,7 +1,9 @@
+"use client"
+
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export default function Loading() {
+export function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />

--- a/app/dashboard/loading.tsx
+++ b/app/dashboard/loading.tsx
@@ -1,7 +1,9 @@
+"use client"
+
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export default function Loading() {
+export function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />

--- a/app/dashboard/notifications/loading.tsx
+++ b/app/dashboard/notifications/loading.tsx
@@ -1,7 +1,9 @@
+"use client"
+
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export default function Loading() {
+export function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />

--- a/app/dashboard/settings/loading.tsx
+++ b/app/dashboard/settings/loading.tsx
@@ -1,7 +1,9 @@
+"use client"
+
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export default function Loading() {
+export function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />

--- a/app/dashboard/users/loading.tsx
+++ b/app/dashboard/users/loading.tsx
@@ -1,7 +1,9 @@
+"use client"
+
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export default function Loading() {
+export function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />

--- a/app/edit-contract/[id]/loading.tsx
+++ b/app/edit-contract/[id]/loading.tsx
@@ -1,7 +1,9 @@
+"use client"
+
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export default function Loading() {
+export function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />

--- a/app/generate-contract/loading.tsx
+++ b/app/generate-contract/loading.tsx
@@ -1,7 +1,9 @@
+"use client"
+
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export default function Loading() {
+export function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,7 +1,9 @@
+"use client"
+
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export default function Loading() {
+export function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />

--- a/app/login/loading.tsx
+++ b/app/login/loading.tsx
@@ -1,7 +1,9 @@
+"use client"
+
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export default function Loading() {
+export function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />

--- a/app/manage-parties/loading.tsx
+++ b/app/manage-parties/loading.tsx
@@ -1,7 +1,9 @@
+"use client"
+
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export default function Loading() {
+export function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />

--- a/app/manage-promoters/[id]/edit/loading.tsx
+++ b/app/manage-promoters/[id]/edit/loading.tsx
@@ -1,7 +1,9 @@
+"use client"
+
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export default function Loading() {
+export function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />

--- a/app/manage-promoters/[id]/loading.tsx
+++ b/app/manage-promoters/[id]/loading.tsx
@@ -1,7 +1,9 @@
+"use client"
+
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export default function Loading() {
+export function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />

--- a/app/manage-promoters/loading.tsx
+++ b/app/manage-promoters/loading.tsx
@@ -1,7 +1,9 @@
+"use client"
+
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export default function Loading() {
+export function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />

--- a/app/promoters/profile-test/loading.tsx
+++ b/app/promoters/profile-test/loading.tsx
@@ -1,7 +1,9 @@
+"use client"
+
 import React from "react"
 import { Loader2 } from "lucide-react"
 
-export default function Loading() {
+export function Loading() {
   return (
     <div className="flex h-full w-full items-center justify-center">
       <Loader2 className="h-10 w-10 animate-spin text-primary" />


### PR DESCRIPTION
## Summary
- export named `Loading` components
- mark loading components as client components for Next.js

## Testing
- `pnpm install` *(fails: forbidden to fetch packages)*
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856bbafc008832698be2ad4acf365df