### PR TITLE
chore: ignore Tailwind at-rule linting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "css.lint.unknownAtRules": "ignore"
+}


### PR DESCRIPTION
## Summary
- add a `.vscode` config to ignore unknown at rules

## Testing
- `pnpm test` *(fails: `jest` not found)*
- `npm run lint` *(fails: `@eslint/eslintrc` module not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856bd68a6e483268c33451ab65ba22f