### PR TITLE
Add VSCode Tailwind lint config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "css.lint.unknownAtRules": "ignore"
+}


### PR DESCRIPTION
## Summary
- add `.vscode/settings.json` to ignore Tailwind `@` rules in the VSCode CSS linter

## Testing
- `pnpm exec next lint` *(fails: Command "next" not found)*
- `pnpm exec tsc --noEmit` *(fails: many missing modules)*
- `pnpm exec jest` *(fails: Command "jest" not found)*


------
https://chatgpt.com/codex/tasks/task_e_6856bdbceb008326a5b2c0c95e9d6699