### PR TITLE
Fix alias for app directory

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -23,6 +23,7 @@ const nextConfig = {
   webpack: (config) => {
     // Allow absolute imports from the /app directory
     config.resolve.alias['app'] = path.resolve(__dirname, 'app')
+    config.resolve.alias['/app'] = path.resolve(__dirname, 'app')
     return config
   },
 }


### PR DESCRIPTION
## Summary
- fix alias to support `/app` imports

## Testing
- `pnpm test` *(fails: ERR_PNPM_OUTDATED_LOCKFILE)*

------
https://chatgpt.com/codex/tasks/task_e_6857c6b0e610832691b71be7589ec7c4