### PR TITLE
Remove duplicate prettier dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,8 +91,6 @@
     "postcss": "^8.5",
     "tailwindcss": "^3.4.17",
     "ts-jest": "^29",
-    "typescript": "^5",
-    "prettier": "^3.2.5",
-    "prettier-plugin-tailwindcss": "^0.5.13"
+    "typescript": "^5"
   }
 }


### PR DESCRIPTION
## Summary
- remove duplicated `prettier` and `prettier-plugin-tailwindcss` entries in `package.json`
- run `pnpm install` (failed due to environment restrictions)

## Testing
- `pnpm install` *(fails: ERR_PNPM_FETCH_403)*

------
https://chatgpt.com/codex/tasks/task_e_6857caff12888326879ab63cb5993cdf