### PR TITLE
Remove duplicate PostCSS config

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "node": "20.x"
   },
   "scripts": {
-    "build": "next build",
-    "dev": "node scripts/build-form.js && next dev",
+    "build": "POSTCSS_CONFIG=postcss.config.mjs next build",
+    "dev": "POSTCSS_CONFIG=postcss.config.mjs node scripts/build-form.js && next dev",
     "lint": "eslint .",
     "start": "next start",
     "pretest": "pnpm install --frozen-lockfile || true",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,7 +1,0 @@
-// postcss.config.js
-module.exports = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-};


### PR DESCRIPTION
## Summary
- keep PostCSS configuration using `postcss.config.mjs`
- set build scripts to reference this file

## Testing
- `npm test` *(fails: pnpm install requires network)*

------
https://chatgpt.com/codex/tasks/task_e_6857cb2bed548326aa86dd345729bf0c