### PR TITLE
Remove unused imports in next config

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,3 @@
-import path from 'path'
-
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
@@ -19,9 +17,6 @@ const nextConfig = {
         pathname: '/storage/v1/object/public/**',
       },
       ],
-  },
-  webpack: (config) => {
-    return config
   },
 }
 


### PR DESCRIPTION
## Summary
- remove `path` import from `next.config.mjs`
- drop redundant `webpack` block

## Testing
- `pnpm test` *(fails: pnpm install --frozen-lockfile requires internet; jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857cdddb42c83269c57bce8a53ffb7b