### PR TITLE
Remove fallback from pretest

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dev": "POSTCSS_CONFIG=postcss.config.mjs node scripts/build-form.js && next dev",
     "lint": "eslint .",
     "start": "next start",
-    "pretest": "pnpm install --frozen-lockfile || true",
+    "pretest": "pnpm install --frozen-lockfile",
     "test": "jest"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- enforce dependency installation in pretest

## Testing
- `pnpm test` *(fails: `ERR_PNPM_OUTDATED_LOCKFILE`)*

------
https://chatgpt.com/codex/tasks/task_e_6857cddfe2e4832680f9e5b787f9b87e