### PR TITLE
Update postcss config references

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "node": "20.x"
   },
   "scripts": {
-    "build": "POSTCSS_CONFIG=postcss.config.mjs next build",
-    "dev": "POSTCSS_CONFIG=postcss.config.mjs node scripts/build-form.js && next dev",
+    "build": "POSTCSS_CONFIG=postcss.config.js next build",
+    "dev": "POSTCSS_CONFIG=postcss.config.js node scripts/build-form.js && next dev",
     "lint": "eslint .",
     "start": "next start",
     "pretest": "pnpm install --frozen-lockfile",


### PR DESCRIPTION
## Summary
- switch scripts to refer to `postcss.config.js`

## Testing
- `pnpm install` *(fails: Forbidden - 403)*
- `npm test` *(fails: pnpm lockfile out of date)*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_6857d34820588326aca9635dcfb6366b