### PR TITLE
Add missing named export for ClientLayout

### DIFF
--- a/app/client-layout.tsx
+++ b/app/client-layout.tsx
@@ -15,8 +15,7 @@ interface ClientLayoutProps {
   locale: string
 }
 
-// Changed to named export
-const ClientLayout = ({ children, messages, locale }: ClientLayoutProps) => {
+export const ClientLayout = ({ children, messages, locale }: ClientLayoutProps) => {
   return (
     <NextIntlClientProvider messages={messages} locale={locale}>
       <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>

--- a/components/promoter-form.tsx
+++ b/components/promoter-form.tsx
@@ -239,3 +239,5 @@ export default function PromoterForm({ initialData }: PromoterFormProps) {
     </Form>
   )
 }
+
+export { PromoterForm }


### PR DESCRIPTION
## Summary
- ensure ClientLayout is exported as a named export
- expose PromoterForm as both default and named export to satisfy imports

## Testing
- `npm run -s test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686101ba905c8326a3bbc4e70e87deca