### PR TITLE
Fix missing Radix package causing install failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "@radix-ui/react-popover": "latest",
     "@radix-ui/react-progress": "latest",
     "@radix-ui/react-radio-group": "latest",
-    "@radix-ui/react-resizable": "^1.0.0",
     "@radix-ui/react-scroll-area": "latest",
     "@radix-ui/react-select": "latest",
     "@radix-ui/react-separator": "latest",


### PR DESCRIPTION
## Summary
- remove invalid dependency `@radix-ui/react-resizable`

## Testing
- `pnpm install` *(fails: GET https://registry.npmjs.org/@eslint/js: Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68610c5a58f483269ca2980ae2affd44