### PR TITLE
Add ContractStatusFilter unit test

### DIFF
--- a/components/contract-status-filter.test.tsx
+++ b/components/contract-status-filter.test.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import { render, screen, fireEvent } from "@testing-library/react"
+import { ContractStatusFilter } from "./contract-status-filter"
+import jest from "jest"
+
+jest.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}))
+
+describe("ContractStatusFilter", () => {
+  it("shows all status options when opened", () => {
+    render(<ContractStatusFilter />)
+
+    fireEvent.click(screen.getByRole("button"))
+
+    const statuses = [
+      /all/i,
+      /Draft/i,
+      /Pending Review/i,
+      /Approved/i,
+      /Signed/i,
+      /Active/i,
+      /Completed/i,
+      /Archived/i,
+    ]
+
+    statuses.forEach((status) => {
+      expect(screen.getByText(status)).toBeInTheDocument()
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add a unit test for ContractStatusFilter that checks each status option

## Testing
- `pnpm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_6861123a80ec8326941eb2bfd2ae27a5