### PR TITLE
Add supabase client helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ build/
 
 # Supabase
 supabase/
+!lib/supabase/

--- a/app/api/contracts/route.ts
+++ b/app/api/contracts/route.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { createClient } from "@/lib/supabase/server"
-import { getSupabaseAdmin } from "@/lib/supabase/admin"
+import { getSupabaseAdmin } from "@/lib/supabase"
 import { contractGeneratorSchema } from "@/lib/schema-generator" // Your Zod schema for validation
 import type { BilingualPdfData } from "@/lib/types"
 import type { Database } from "@/types/supabase"

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -1,0 +1,12 @@
+import { createClient as createBrowserClient } from "@supabase/supabase-js"
+import type { Database } from "@/types/supabase"
+
+export function createClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+  if (!supabaseUrl) throw new Error("Missing NEXT_PUBLIC_SUPABASE_URL")
+  if (!supabaseAnonKey) throw new Error("Missing NEXT_PUBLIC_SUPABASE_ANON_KEY")
+
+  return createBrowserClient<Database>(supabaseUrl, supabaseAnonKey)
+}

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,0 +1,35 @@
+import { createServerClient, type CookieOptions } from "@supabase/ssr"
+import { cookies } from "next/headers"
+import type { Database } from "@/types/supabase"
+
+export function createClient() {
+  const cookieStore = cookies()
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+  if (!supabaseUrl) throw new Error("Missing NEXT_PUBLIC_SUPABASE_URL")
+  if (!supabaseAnonKey) throw new Error("Missing NEXT_PUBLIC_SUPABASE_ANON_KEY")
+
+  return createServerClient<Database>(supabaseUrl, supabaseAnonKey, {
+    cookies: {
+      get(name: string) {
+        return cookieStore.get(name)?.value
+      },
+      set(name: string, value: string, options: CookieOptions) {
+        try {
+          cookieStore.set({ name, value, ...options })
+        } catch (error) {
+          console.warn("Could not set cookie from Server Component:", error)
+        }
+      },
+      remove(name: string, options: CookieOptions) {
+        try {
+          cookieStore.set({ name, value: "", ...options })
+        } catch (error) {
+          console.warn("Could not remove cookie from Server Component:", error)
+        }
+      },
+    },
+  })
+}


### PR DESCRIPTION
## Summary
- add client and server helper functions under `lib/supabase/`
- adjust API route to import `getSupabaseAdmin` from root module
- update `.gitignore` so `lib/supabase/` is committed

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npm test` *(fails: various jest errors)*

------
https://chatgpt.com/codex/tasks/task_e_6861122f373c8326b6addfe3c926d06d