### PR TITLE
refactor: centralize dashboard types

### DIFF
--- a/lib/dashboard-data.client.ts
+++ b/lib/dashboard-data.client.ts
@@ -1,50 +1,12 @@
 import { createClient } from "@/lib/supabase/client"
-
-export interface DashboardAnalytics {
-  totalContracts: number
-  pendingContracts: number
-  completedContracts: number
-  failedContracts: number
-  contractsThisMonth: number
-  contractsLastMonth: number
-  averageProcessingTime: number
-  successRate: number
-}
-
-export interface PendingReview {
-  id: string
-  contract_name: string
-  status: string
-  updated_at: string
-}
-
-export interface AdminAction {
-  id: string
-  action: string
-  created_at: string
-  user_id: string
-}
-
-export interface Notification {
-  id: string
-  message: string
-  created_at: string
-  read: boolean
-}
-
-export interface User {
-  id: string
-  email: string
-  role: string
-  created_at: string
-}
-
-interface ServerActionResponse<T = any> {
-  success: boolean
-  message: string
-  data?: T | null
-  errors?: Record<string, string[]> | null
-}
+import type {
+  AdminAction,
+  DashboardAnalytics,
+  Notification,
+  PendingReview,
+  ServerActionResponse,
+  User,
+} from "./dashboard-types"
 
 export async function getDashboardAnalytics(): Promise<ServerActionResponse<DashboardAnalytics>> {
   const supabase = createClient()

--- a/lib/dashboard-data.server.ts
+++ b/lib/dashboard-data.server.ts
@@ -1,13 +1,13 @@
 import { createClient } from "@/lib/supabase/server"
 import 'server-only' // Mark this module as server-only
-import type { AdminAction, DashboardAnalytics, Notification, PendingReview, User } from "./dashboard-types"
-
-interface ServerActionResponse<T = any> {
-  success: boolean
-  message: string
-  data?: T | null
-  errors?: Record<string, string[]> | null
-}
+import type {
+  AdminAction,
+  DashboardAnalytics,
+  Notification,
+  PendingReview,
+  ServerActionResponse,
+  User,
+} from "./dashboard-types"
 
 // Server-only implementations
 export async function getDashboardAnalytics(): Promise<ServerActionResponse<DashboardAnalytics>> {

--- a/lib/dashboard-data.ts
+++ b/lib/dashboard-data.ts
@@ -1,15 +1,16 @@
 // Re-export from our unified data API
 export * from './data'
-import type { AdminAction, DashboardAnalytics, Notification, PendingReview, User } from "./dashboard-types"
+import type {
+  AdminAction,
+  DashboardAnalytics,
+  Notification,
+  PendingReview,
+  ServerActionResponse,
+  User,
+} from "./dashboard-types"
 // Import only browser client statically
 import { createClient as createBrowserClient } from "@/lib/supabase/client"
 
-interface ServerActionResponse<T = any> {
-  success: boolean
-  message: string
-  data?: T | null
-  errors?: Record<string, string[]> | null
-}
 
 // Helper function to get the appropriate client
 async function getSupabaseClient() {


### PR DESCRIPTION
## Summary
- consolidate dashboard-related interfaces under `dashboard-types`
- update dashboard-data modules to use the shared types

## Testing
- `npm run lint` *(fails: prompts for configuration)*
- `npm run build` *(fails: cannot fetch Inter font due to network restrictions)*
- `npx tsc --noEmit` *(fails: missing jest types and Next.js issues)*

------
https://chatgpt.com/codex/tasks/task_e_6861a0f237908326b1a35a8a7280bbfd