### PR TITLE
Fix server client invocation

### DIFF
--- a/lib/dashboard-data.ts
+++ b/lib/dashboard-data.ts
@@ -21,10 +21,8 @@ async function getSupabaseClient() {
   // In server environment
   try {
     // Dynamically import server-only modules
-    const { cookies } = await import('next/headers')
-    const { createClient: createServerClient } = await import("@/lib/supabase/server") 
-    const cookieStore = cookies()
-    return createServerClient(cookieStore)
+    const { createClient: createServerClient } = await import("@/lib/supabase/server")
+    return createServerClient()
   } catch (error) {
     // Fallback to browser client
     console.warn('Falling back to browser client in server environment')


### PR DESCRIPTION
## Summary
- remove unused `cookieStore` argument when selecting the server Supabase client

## Testing
- `npx tsc --noEmit lib/dashboard-data.ts` *(fails: Cannot find module '@/lib/supabase/client')*

------
https://chatgpt.com/codex/tasks/task_e_6861a0f4fac88326b7a61f95127ee1d9