### PR TITLE
Fix dashboard types import

### DIFF
--- a/lib/dashboard-data.client.ts
+++ b/lib/dashboard-data.client.ts
@@ -1,11 +1,13 @@
 import { createClient } from "@/lib/supabase/client"
 import type {
-  AdminAction,
   DashboardAnalytics,
-  Notification,
+  ContractTrend,
+  ContractStatusDistribution,
   PendingReview,
-  ServerActionResponse,
+  AdminAction,
+  Notification,
   User,
+  ServerActionResponse,
 } from "./dashboard-types"
 
 export async function getDashboardAnalytics(): Promise<ServerActionResponse<DashboardAnalytics>> {


### PR DESCRIPTION
## Summary
- import ContractTrend and ContractStatusDistribution types in `dashboard-data.client.ts`

## Testing
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6861a464a6148326919893e5681c7140