### PR TITLE
Fix dashboard client exports

### DIFF
--- a/lib/dashboard-data.client.js
+++ b/lib/dashboard-data.client.js
@@ -1,0 +1,5 @@
+export {
+  getDashboardAnalytics,
+  getPendingReviews,
+  getAdminActions,
+} from './dashboard-data.client'

--- a/lib/dashboard-data.client.ts
+++ b/lib/dashboard-data.client.ts
@@ -1,3 +1,5 @@
+"use client"
+
 import { createClient } from "@/lib/supabase/client"
 import type {
   DashboardAnalytics,


### PR DESCRIPTION
## Summary
- mark dashboard data module as a client module
- add JS helper that re-exports dashboard data API

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861a7c2798c83268a7b665acc0c7ec8