### PR TITLE
Fix dashboard client export

### DIFF
--- a/lib/dashboard-data.client.js
+++ b/lib/dashboard-data.client.js
@@ -1,5 +1,1 @@
-export {
-  getDashboardAnalytics,
-  getPendingReviews,
-  getAdminActions,
-} from './dashboard-data.client'
+export * from './dashboard-data.client.ts'


### PR DESCRIPTION
## Summary
- re-export client functions from dashboard-data.client.ts

## Testing
- `npm run lint` *(fails: interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_6861a93b6bbc8326af6f96efd730b143