### PR TITLE
Fix interface import in dashboard-data.client

### DIFF
--- a/lib/dashboard-data.client.ts
+++ b/lib/dashboard-data.client.ts
@@ -1,13 +1,7 @@
 "use client";
 
 import { createClient } from "@/lib/supabase/client";
-
-// Simple response interface
-interface ServerActionResponse<T = any> {
-  success: boolean;
-  message: string;
-  data?: T | null;
-}
+import type { ServerActionResponse } from "./dashboard-types";
 
 /**
  * Fetches dashboard analytics data


### PR DESCRIPTION
## Summary
- reuse `ServerActionResponse` type instead of redefining it

## Testing
- `npm run lint` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861b30f01bc8326aeb82a6eb6f8dcb5