### PR TITLE
Ensure Supabase server modules are server-only

### DIFF
--- a/lib/supabase/server.server.ts
+++ b/lib/supabase/server.server.ts
@@ -1,3 +1,4 @@
+import 'server-only'
 import { createServerClient } from "@supabase/ssr"
 import { cookies } from "next/headers"
 import type { Database } from "@/types/supabase"

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,3 +1,4 @@
+import 'server-only'
 import { createServerClient } from "@supabase/ssr"
 import { cookies } from "next/headers"
 import type { Database } from "@/types/supabase"


### PR DESCRIPTION
## Summary
- mark Supabase server clients with `server-only` import
- verify that server modules are not imported in client components

## Testing
- `npm run lint` *(fails: prompts for config)*

------
https://chatgpt.com/codex/tasks/task_e_6861b85ea8f88326abc2e6e2c84d2874