### PR TITLE
Add Jest type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "eslint-config-next": "14.1.0",
     "postcss": "^8.5",
     "tailwindcss": "^3.3.0",
-    "typescript": "^5"
+    "typescript": "^5",
+    "@types/jest": "^29"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
+    "types": ["jest"],
     "incremental": true,
     "plugins": [
       {


### PR DESCRIPTION
## Summary
- add `@types/jest` to devDependencies
- register Jest globals in TypeScript config

## Testing
- `pnpm install` *(fails: 403 Forbidden)*
- `pnpm exec tsc --noEmit` *(fails: Cannot find type definition file for 'jest')*


------
https://chatgpt.com/codex/tasks/task_e_6861b86235b483268ca71cc91e1603a0