### PR TITLE
Remove extraneous fs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "date-fns": "latest",
     "embla-carousel-react": "latest",
     "eslint-plugin-react": "latest",
-    "fs": "latest",
     "globals": "latest",
     "i18next": "latest",
     "immer": "latest",


### PR DESCRIPTION
## Summary
- trim unused `fs` package from dependencies

## Testing
- `npx jest` *(fails: jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_6861bbdc3854832698cc77a628f36487