### PR TITLE
Fix Pending Review status string

### DIFF
--- a/lib/dashboard-data.client.ts
+++ b/lib/dashboard-data.client.ts
@@ -53,7 +53,7 @@ export async function getPendingReviews(): Promise<
     const { data, error } = await supabase
       .from("contracts")
       .select("id, contract_name, status, updated_at")
-      .eq("status", "pending_review")
+      .eq("status", "Pending Review")
       .order("updated_at", { ascending: false });
     
     if (error) {

--- a/lib/dashboard-data.server.ts
+++ b/lib/dashboard-data.server.ts
@@ -37,7 +37,7 @@ export async function getPendingReviews(): Promise<ServerActionResponse<PendingR
     const { data, error } = await supabase
       .from("contracts")
       .select("id, contract_name, status, updated_at")
-      .in("status", ["pending", "processing", "pending_review"])
+      .in("status", ["pending", "processing", "Pending Review"])
       .order("updated_at", { ascending: false })
       .limit(10)
 

--- a/types/custom.ts
+++ b/types/custom.ts
@@ -17,7 +17,7 @@ export const promoterFormSchema = z.object({
   id_card_number: z.string().min(5, "ID card number is required."),
   // Add other promoter fields as necessary, e.g., status, employer_id, etc.
   // For example:
-  // status: z.enum(["active", "inactive", "pending_review"]),
+  // status: z.enum(["active", "inactive", "Pending Review"]),
   // employer_id: z.string().uuid().nullable(),
   id_card_url: z.string().url().optional().nullable(),
   passport_url: z.string().url().optional().nullable(),
@@ -29,7 +29,7 @@ export type PromoterFormData = z.infer<typeof promoterFormSchema>
 export const promoterStatusesList = [
   { value: "active", label: "Active" },
   { value: "inactive", label: "Inactive" },
-  { value: "pending_review", label: "Pending Review" },
+  { value: "Pending Review", label: "Pending Review" },
   // Add other statuses if needed
 ]
 


### PR DESCRIPTION
## Summary
- use `Pending Review` instead of `pending_review` when fetching dashboard info
- update promoter status options to match casing

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6861bbcccec08326a861f50de4aa8bb4