### PR TITLE
Fix dashboard client exports

### DIFF
--- a/lib/dashboard-data.client.js
+++ b/lib/dashboard-data.client.js
@@ -1,0 +1,1 @@
+export { getDashboardAnalytics, getPendingReviews, getAdminActions, getAuditLogs, getNotifications, getUsers } from "./dashboard-data.client.ts";


### PR DESCRIPTION
## Summary
- restore `lib/dashboard-data.client.js` re-export shim for runtime compatibility

## Testing
- `npm test` *(fails: jest-environment-jsdom not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861be5287608326b4269dbaa36c3df2