### PR TITLE
Handle fetch errors with structured responses

### DIFF
--- a/app/actions/contracts.ts
+++ b/app/actions/contracts.ts
@@ -3,71 +3,103 @@
 import { createClient } from "@/lib/supabase/server"
 import { revalidatePath } from "next/cache"
 import type { Contract } from "@/lib/types"
+import type { ServerActionResponse } from "@/lib/dashboard-types"
 
-export async function getContracts(): Promise<Contract[]> {
+export async function getContracts(): Promise<ServerActionResponse<Contract[]>> {
   const supabase = await createClient()
 
   const { data, error } = await supabase.from("contracts").select("*").order("created_at", { ascending: false })
 
   if (error) {
     console.error("Error fetching contracts:", error)
-    return []
+    return { success: false, message: `Failed to fetch contracts: ${error.message}` }
   }
 
-  return data || []
+  return { success: true, message: "Contracts fetched successfully", data: data || [] }
 }
 
-export async function getContractById(id: string): Promise<Contract | null> {
+export async function getContractById(id: string): Promise<ServerActionResponse<Contract>> {
   const supabase = await createClient()
 
   const { data, error } = await supabase.from("contracts").select("*").eq("id", id).single()
 
   if (error) {
     console.error("Error fetching contract:", error)
-    return null
+    return { success: false, message: `Failed to fetch contract: ${error.message}` }
   }
 
-  return data
+  if (!data) {
+    return { success: false, message: "Contract not found" }
+  }
+
+  return { success: true, message: "Contract fetched successfully", data }
 }
 
-export async function createContract(contractData: Partial<Contract>) {
+export async function createContract(
+  _prevState: unknown,
+  contractData: FormData | Partial<Contract>,
+): Promise<ServerActionResponse<Contract>> {
   const supabase = await createClient()
 
-  const { data, error } = await supabase.from("contracts").insert(contractData).select().single()
+  const values =
+    contractData instanceof FormData
+      ? Object.fromEntries(contractData.entries())
+      : contractData
+
+  const { data, error } = await supabase
+    .from("contracts")
+    .insert(values)
+    .select()
+    .single()
 
   if (error) {
     console.error("Error creating contract:", error)
-    throw new Error("Failed to create contract")
+    return { success: false, message: `Failed to create contract: ${error.message}` }
   }
 
   revalidatePath("/contracts")
-  return data
+  return { success: true, message: "Contract created successfully", data: data as Contract }
 }
 
-export async function updateContract(id: string, contractData: Partial<Contract>) {
+export async function updateContract(
+  id: string,
+  _prevState: unknown,
+  contractData: FormData | Partial<Contract>,
+): Promise<ServerActionResponse<Contract>> {
   const supabase = await createClient()
 
-  const { data, error } = await supabase.from("contracts").update(contractData).eq("id", id).select().single()
+  const values =
+    contractData instanceof FormData
+      ? Object.fromEntries(contractData.entries())
+      : contractData
+
+  const { data, error } = await supabase
+    .from("contracts")
+    .update(values)
+    .eq("id", id)
+    .select()
+    .single()
 
   if (error) {
     console.error("Error updating contract:", error)
-    throw new Error("Failed to update contract")
+    return { success: false, message: `Failed to update contract: ${error.message}` }
   }
 
   revalidatePath("/contracts")
   revalidatePath(`/contracts/${id}`)
-  return data
+  return { success: true, message: "Contract updated successfully", data: data as Contract }
 }
 
-export async function deleteContract(id: string) {
+export async function deleteContract(id: string): Promise<ServerActionResponse<null>> {
   const supabase = await createClient()
 
   const { error } = await supabase.from("contracts").delete().eq("id", id)
 
   if (error) {
     console.error("Error deleting contract:", error)
-    throw new Error("Failed to delete contract")
+    return { success: false, message: `Failed to delete contract: ${error.message}` }
   }
 
   revalidatePath("/contracts")
+  return { success: true, message: "Contract deleted successfully", data: null }
 }

--- a/app/actions/parties.ts
+++ b/app/actions/parties.ts
@@ -3,70 +3,93 @@
 import { createClient } from "@/lib/supabase/server"
 import { revalidatePath } from "next/cache"
 import type { Party } from "@/lib/types"
+import type { ServerActionResponse } from "@/lib/dashboard-types"
 
-export async function getParties(): Promise<Party[]> {
+export async function getParties(): Promise<ServerActionResponse<Party[]>> {
   const supabase = await createClient()
 
   const { data, error } = await supabase.from("parties").select("*").order("created_at", { ascending: false })
 
   if (error) {
     console.error("Error fetching parties:", error)
-    return []
+    return { success: false, message: `Failed to fetch parties: ${error.message}` }
   }
 
-  return data || []
+  return { success: true, message: "Parties fetched successfully", data: data || [] }
 }
 
-export async function getPartyById(id: string): Promise<Party | null> {
+export async function getPartyById(id: string): Promise<ServerActionResponse<Party>> {
   const supabase = await createClient()
 
   const { data, error } = await supabase.from("parties").select("*").eq("id", id).single()
 
   if (error) {
     console.error("Error fetching party:", error)
-    return null
+    return { success: false, message: `Failed to fetch party: ${error.message}` }
   }
 
-  return data
+  if (!data) {
+    return { success: false, message: "Party not found" }
+  }
+
+  return { success: true, message: "Party fetched successfully", data }
 }
 
-export async function createParty(partyData: Partial<Party>) {
+export async function createParty(
+  _prevState: unknown,
+  partyData: FormData | Partial<Party>,
+): Promise<ServerActionResponse<Party>> {
   const supabase = await createClient()
 
-  const { data, error } = await supabase.from("parties").insert(partyData).select().single()
+  const values =
+    partyData instanceof FormData
+      ? Object.fromEntries(partyData.entries())
+      : partyData
+
+  const { data, error } = await supabase.from("parties").insert(values).select().single()
 
   if (error) {
     console.error("Error creating party:", error)
-    throw new Error("Failed to create party")
+    return { success: false, message: `Failed to create party: ${error.message}` }
   }
 
   revalidatePath("/manage-parties")
-  return data
+  return { success: true, message: "Party created successfully", data: data as Party }
 }
 
-export async function updateParty(id: string, partyData: Partial<Party>) {
+export async function updateParty(
+  id: string,
+  _prevState: unknown,
+  partyData: FormData | Partial<Party>,
+): Promise<ServerActionResponse<Party>> {
   const supabase = await createClient()
 
-  const { data, error } = await supabase.from("parties").update(partyData).eq("id", id).select().single()
+  const values =
+    partyData instanceof FormData
+      ? Object.fromEntries(partyData.entries())
+      : partyData
+
+  const { data, error } = await supabase.from("parties").update(values).eq("id", id).select().single()
 
   if (error) {
     console.error("Error updating party:", error)
-    throw new Error("Failed to update party")
+    return { success: false, message: `Failed to update party: ${error.message}` }
   }
 
   revalidatePath("/manage-parties")
-  return data
+  return { success: true, message: "Party updated successfully", data: data as Party }
 }
 
-export async function deleteParty(id: string) {
+export async function deleteParty(id: string): Promise<ServerActionResponse<null>> {
   const supabase = await createClient()
 
   const { error } = await supabase.from("parties").delete().eq("id", id)
 
   if (error) {
     console.error("Error deleting party:", error)
-    throw new Error("Failed to delete party")
+    return { success: false, message: `Failed to delete party: ${error.message}` }
   }
 
   revalidatePath("/manage-parties")
+  return { success: true, message: "Party deleted successfully", data: null }
 }

--- a/app/contracts/[id]/page.tsx
+++ b/app/contracts/[id]/page.tsx
@@ -20,12 +20,14 @@ export default async function ContractDetailsPage({ params }: ContractDetailsPag
   redirect("/en/contracts")
 
   const t = await getTranslations("ContractDetailsPage")
-  const { data: contract, error } = await getContractById(params.id)
+  const result = await getContractById(params.id)
 
-  if (error || !contract) {
-    console.error("Error fetching contract:", error)
+  if (!result.success || !result.data) {
+    console.error("Error fetching contract:", result.message)
     notFound()
   }
+
+  const contract = result.data
 
   return (
     <div className="container mx-auto py-8 px-4 md:px-6">

--- a/app/manage-promoters/[id]/page.tsx
+++ b/app/manage-promoters/[id]/page.tsx
@@ -20,12 +20,14 @@ export default async function PromoterDetailsPage({ params }: PromoterDetailsPag
   redirect("/en/manage-promoters")
 
   const t = await getTranslations("PromoterDetailsPage")
-  const { data: promoter, error } = await getPromoterById(params.id)
+  const result = await getPromoterById(params.id)
 
-  if (error || !promoter) {
-    console.error("Error fetching promoter:", error)
+  if (!result.success || !result.data) {
+    console.error("Error fetching promoter:", result.message)
     notFound()
   }
+
+  const promoter = result.data
 
   return (
     <div className="container mx-auto py-8 px-4 md:px-6">

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -1,4 +1,5 @@
 import type { Contract, Party, Promoter } from "./types"
+import type { ServerActionResponse } from "./dashboard-types"
 // Only import the browser client statically
 import { createClient as createBrowserClient } from "@/lib/supabase/client"
 
@@ -21,7 +22,10 @@ async function getSupabaseClient() {
   }
 }
 
-export async function getContractsData(query?: string, status?: string): Promise<Contract[]> {
+export async function getContractsData(
+  query?: string,
+  status?: string,
+): Promise<ServerActionResponse<Contract[]>> {
   const supabase = await getSupabaseClient()
   
   // Rest of the function remains the same
@@ -57,20 +61,21 @@ export async function getContractsData(query?: string, status?: string): Promise
 
   if (error) {
     console.error("Error fetching contracts:", error)
-    return []
+    return { success: false, message: `Failed to fetch contracts: ${error.message}` }
   }
 
-  // Flatten the data to match the Contract type
-  return data.map((contract: any) => ({
+  const contracts = (data || []).map((contract: any) => ({
     ...contract,
     party_a_name: contract.parties_contracts_party_a_id_fkey?.name || "N/A",
     party_b_name: contract.parties_contracts_party_b_id_fkey?.name || "N/A",
     promoter_name: contract.promoters?.name || "N/A",
   })) as Contract[]
+
+  return { success: true, message: "Contracts fetched successfully", data: contracts }
 }
 
 // Update all other functions to use await getSupabaseClient()
-export async function getContractById(id: string): Promise<Contract | null> {
+export async function getContractById(id: string): Promise<ServerActionResponse<Contract>> {
   const supabase = await getSupabaseClient()
   
   // Rest of the function remains the same
@@ -97,23 +102,24 @@ export async function getContractById(id: string): Promise<Contract | null> {
 
   if (error) {
     console.error("Error fetching contract:", error)
-    return null
+    return { success: false, message: `Failed to fetch contract: ${error.message}` }
   }
 
   if (!data) {
-    return null
+    return { success: false, message: "Contract not found" }
   }
 
-  // Flatten the data to match the Contract type
-  return {
+  const contract = {
     ...data,
     party_a_name: (data as any).parties_contracts_party_a_id_fkey?.name || "N/A",
     party_b_name: (data as any).parties_contracts_party_b_id_fkey?.name || "N/A",
     promoter_name: (data as any).promoters?.name || "N/A",
   } as Contract
+
+  return { success: true, message: "Contract fetched successfully", data: contract }
 }
 
-export async function getParties(): Promise<Party[]> {
+export async function getParties(): Promise<ServerActionResponse<Party[]>> {
   const supabase = await getSupabaseClient()
   
   // Rest of the function remains the same
@@ -121,12 +127,12 @@ export async function getParties(): Promise<Party[]> {
 
   if (error) {
     console.error("Error fetching parties:", error)
-    return []
+    return { success: false, message: `Failed to fetch parties: ${error.message}` }
   }
-  return data as Party[]
+  return { success: true, message: "Parties fetched successfully", data: data as Party[] }
 }
 
-export async function getPartyById(id: string): Promise<Party | null> {
+export async function getPartyById(id: string): Promise<ServerActionResponse<Party>> {
   const supabase = await getSupabaseClient()
   
   // Rest of the function remains the same
@@ -134,12 +140,15 @@ export async function getPartyById(id: string): Promise<Party | null> {
 
   if (error) {
     console.error("Error fetching party:", error)
-    return null
+    return { success: false, message: `Failed to fetch party: ${error.message}` }
   }
-  return data as Party
+  if (!data) {
+    return { success: false, message: "Party not found" }
+  }
+  return { success: true, message: "Party fetched successfully", data: data as Party }
 }
 
-export async function getPromoters(): Promise<Promoter[]> {
+export async function getPromoters(): Promise<ServerActionResponse<Promoter[]>> {
   const supabase = await getSupabaseClient()
   
   // Rest of the function remains the same
@@ -147,12 +156,12 @@ export async function getPromoters(): Promise<Promoter[]> {
 
   if (error) {
     console.error("Error fetching promoters:", error)
-    return []
+    return { success: false, message: `Failed to fetch promoters: ${error.message}` }
   }
-  return data as Promoter[]
+  return { success: true, message: "Promoters fetched successfully", data: data as Promoter[] }
 }
 
-export async function getPromoterById(id: string): Promise<Promoter | null> {
+export async function getPromoterById(id: string): Promise<ServerActionResponse<Promoter>> {
   const supabase = await getSupabaseClient()
   
   // Rest of the function remains the same
@@ -160,7 +169,10 @@ export async function getPromoterById(id: string): Promise<Promoter | null> {
 
   if (error) {
     console.error("Error fetching promoter:", error)
-    return null
+    return { success: false, message: `Failed to fetch promoter: ${error.message}` }
   }
-  return data as Promoter
+  if (!data) {
+    return { success: false, message: "Promoter not found" }
+  }
+  return { success: true, message: "Promoter fetched successfully", data: data as Promoter }
 }


### PR DESCRIPTION
## Summary
- return `ServerActionResponse` objects from data actions
- convert dashboard data utilities to provide structured feedback
- propagate structured errors to contract and promoter detail pages

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*
- `npx tsc -p tsconfig.json` *(fails due to missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68626e6dd05c8326a2a165ec88cbcedd