### PR TITLE
Improve Supabase env handling

### DIFF
--- a/lib/__tests__/supabase-env.test.ts
+++ b/lib/__tests__/supabase-env.test.ts
@@ -1,33 +1,32 @@
-import { z } from "zod"
+import { describe, it, expect, beforeEach, afterEach, jest } from "@jest/globals"
 
-describe("Supabase Environment Variables", () => {
-  it("should have NEXT_PUBLIC_SUPABASE_URL defined", () => {
-    expect(process.env.NEXT_PUBLIC_SUPABASE_URL).toBeDefined()
-    expect(typeof process.env.NEXT_PUBLIC_SUPABASE_URL).toBe("string")
-    expect(process.env.NEXT_PUBLIC_SUPABASE_URL).not.toBe("")
-    // Optionally, validate it's a URL
-    expect(() => z.string().url().parse(process.env.NEXT_PUBLIC_SUPABASE_URL)).not.toThrow()
+const originalEnv = { ...process.env }
+
+describe("Supabase module environment checks", () => {
+  beforeEach(() => {
+    jest.resetModules()
+    process.env = { ...originalEnv }
   })
 
-  it("should have NEXT_PUBLIC_SUPABASE_ANON_KEY defined", () => {
-    expect(process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY).toBeDefined()
-    expect(typeof process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY).toBe("string")
-    expect(process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY).not.toBe("")
+  afterEach(() => {
+    process.env = originalEnv
   })
 
-  it("should have SUPABASE_SERVICE_ROLE_KEY defined (for server-side operations)", () => {
-    // This key is typically only used on the server, so it might not be available in all test environments
-    // For client-side tests, you might mock it or skip this test.
-    // For server-side tests, ensure it's set.
-    if (typeof process !== "undefined" && process.env.NODE_ENV === "test") {
-      // In a typical Next.js setup, server-side envs are available during build/runtime
-      // For Jest, you might need to explicitly set it in setupFiles or mock it.
-      // This test assumes it's available if running in an environment where it should be.
-      console.warn("Skipping SUPABASE_SERVICE_ROLE_KEY check in client-side test environment.")
-    } else {
-      expect(process.env.SUPABASE_SERVICE_ROLE_KEY).toBeDefined()
-      expect(typeof process.env.SUPABASE_SERVICE_ROLE_KEY).toBe("string")
-      expect(process.env.SUPABASE_SERVICE_ROLE_KEY).not.toBe("")
-    }
+  it("throws if NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY are missing", () => {
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL
+    delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+    expect(() => require("../supabase")).toThrow(
+      "Supabase URL and Anon Key must be defined in environment variables.",
+    )
+  })
+
+  it("throws if SUPABASE_SERVICE_ROLE_KEY is missing", () => {
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY
+
+    expect(() => require("../supabaseServer")).toThrow(
+      "Supabase URL and Service Role Key must be defined in environment variables for server-side operations.",
+    )
   })
 })

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -6,9 +6,9 @@ const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 
 if (!supabaseUrl || !supabaseAnonKey) {
-  console.error("Supabase URL and Anon Key must be defined in environment variables.")
-  // In a real application, you might throw an error or handle this more gracefully
-  // For development, we'll proceed with undefined which will likely cause runtime errors
+  throw new Error(
+    "Supabase URL and Anon Key must be defined in environment variables.",
+  )
 }
 
 export const supabase = createClient<Database>(supabaseUrl || "", supabaseAnonKey || "")

--- a/lib/supabaseServer.ts
+++ b/lib/supabaseServer.ts
@@ -7,10 +7,9 @@ const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
 const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
 
 if (!supabaseUrl || !supabaseServiceRoleKey) {
-  console.error(
+  throw new Error(
     "Supabase URL and Service Role Key must be defined in environment variables for server-side operations.",
   )
-  // In a real application, you might throw an error or handle this more gracefully
 }
 
 export const supabaseAdmin = createClient<Database>(supabaseUrl || "", supabaseServiceRoleKey || "", {


### PR DESCRIPTION
## Summary
- throw errors during Supabase client initialization if required env vars are missing
- adjust tests to expect thrown errors when env vars are absent

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_68626e687cc48326b9da8c3a79946d6e